### PR TITLE
New Feature: crud for blocks of nginx rpass config

### DIFF
--- a/rpaas/api.py
+++ b/rpaas/api.py
@@ -243,8 +243,6 @@ def add_block(name):
         return 'please, send content for this block', 400
     try:
         get_manager().add_block(name, block_name, content)
-    except storage.InstanceNotFoundError:
-        return "Instance not found", 404
     except manager.NotReadyError as e:
         return "Instance not ready: {}".format(e), 412
     return "", 201
@@ -258,11 +256,20 @@ def delete_block(name):
         return 'missing block_name', 400
     try:
         get_manager().delete_block(name, block_name)
-    except storage.InstanceNotFoundError:
-        return "Instance not found", 404
     except manager.NotReadyError as e:
         return "Instance not ready: {}".format(e), 412
     return "", 200
+
+
+@api.route("/resources/<name>/block", methods=["GET"])
+@auth.required
+def list_block(name):
+    try:
+        info = get_manager().list_blocks(name)
+        return Response(response=json.dumps(info), status=200,
+                        mimetype="application/json")
+    except manager.NotReadyError as e:
+        return "Instance not ready: {}".format(e), 412
 
 
 @api.route("/resources/<name>/purge", methods=["POST"])

--- a/rpaas/api.py
+++ b/rpaas/api.py
@@ -250,6 +250,21 @@ def add_block(name):
     return "", 201
 
 
+@api.route("/resources/<name>/block", methods=["DELETE"])
+@auth.required
+def delete_block(name):
+    block_name = request.form.get('block_name')
+    if not block_name:
+        return 'missing block_name', 400
+    try:
+        get_manager().delete_block(name, block_name)
+    except storage.InstanceNotFoundError:
+        return "Instance not found", 404
+    except manager.NotReadyError as e:
+        return "Instance not ready: {}".format(e), 412
+    return "", 200
+
+
 @api.route("/resources/<name>/purge", methods=["POST"])
 @auth.required
 def purge_location(name):

--- a/rpaas/api.py
+++ b/rpaas/api.py
@@ -238,9 +238,9 @@ def add_block(name):
     content = request.form.get('content')
     block_name = request.form.get('block_name')
     if block_name not in ('server', 'http'):
-        return 'please, send block_name for this block (server or http)', 400
+        return 'invalid block_name (valid values are "server" or "http")', 400
     if not content:
-        return 'please, send content for this block', 400
+        return 'missing content', 400
     try:
         get_manager().add_block(name, block_name, content)
     except manager.NotReadyError as e:
@@ -248,12 +248,9 @@ def add_block(name):
     return "", 201
 
 
-@api.route("/resources/<name>/block", methods=["DELETE"])
+@api.route("/resources/<name>/block/<block_name>", methods=["DELETE"])
 @auth.required
-def delete_block(name):
-    block_name = request.form.get('block_name')
-    if not block_name:
-        return 'missing block_name', 400
+def delete_block(name, block_name):
     try:
         get_manager().delete_block(name, block_name)
     except manager.NotReadyError as e:

--- a/rpaas/api.py
+++ b/rpaas/api.py
@@ -232,6 +232,24 @@ def list_routes(name):
         return "Instance not found", 404
 
 
+@api.route("/resource/<name>/block", methods=["POST"])
+@auth.required
+def add_block(name):
+    content = request.form.get('content')
+    block_name = request.form.get('block_name')
+    if block_name not in ('server', 'http'):
+        return 'please, send block_name for this block (server or http)', 400
+    if not content:
+        return 'please, send content for this block', 400
+    try:
+        get_manager().add_block(name, block_name, content)
+    except storage.InstanceNotFoundError:
+        return "Instance not found", 404
+    except manager.NotReadyError as e:
+        return "Instance not ready: {}".format(e), 412
+    return "", 201
+
+
 @api.route("/resources/<name>/purge", methods=["POST"])
 @auth.required
 def purge_location(name):

--- a/rpaas/consul_manager.py
+++ b/rpaas/consul_manager.py
@@ -58,6 +58,10 @@ class ConsulManager(object):
     def remove_location(self, instance_name, path):
         self.client.kv.delete(self._location_key(instance_name, path))
 
+    def write_block(self, instance_name, block_name, content):
+        content = content.strip()
+        self.client.kv.put(self._block_key(instance_name, block_name), content)
+
     def get_certificate(self, instance_name):
         cert = self.client.kv.get(self._ssl_cert_key(instance_name))[1]
         key = self.client.kv.get(self._ssl_key_key(instance_name))[1]
@@ -80,6 +84,11 @@ class ConsulManager(object):
         if path != "/":
             location_key = path.replace("/", "___")
         return self._key(instance_name, "locations/" + location_key)
+
+    def _block_key(self, instance_name, block_name):
+        block_key = "ROOT"
+        return self._key(instance_name, "blocks/%s/%s" % (block_name,
+                                                          block_key))
 
     def _key(self, instance_name, suffix=None):
         key = "{}/{}".format(self.service_name, instance_name)

--- a/rpaas/consul_manager.py
+++ b/rpaas/consul_manager.py
@@ -62,6 +62,9 @@ class ConsulManager(object):
         content = content.strip()
         self.client.kv.put(self._block_key(instance_name, block_name), content)
 
+    def remove_block(self, instance_name, block_name):
+        self.client.kv.delete(self._block_key(instance_name, block_name))
+
     def get_certificate(self, instance_name):
         cert = self.client.kv.get(self._ssl_cert_key(instance_name))[1]
         key = self.client.kv.get(self._ssl_key_key(instance_name))[1]

--- a/rpaas/consul_manager.py
+++ b/rpaas/consul_manager.py
@@ -65,6 +65,10 @@ class ConsulManager(object):
     def remove_block(self, instance_name, block_name):
         self.client.kv.delete(self._block_key(instance_name, block_name))
 
+    def list_blocks(self, instance_name, block_name=None):
+        return self.client.kv.get(self._block_key(instance_name, block_name),
+                                  recurse=True)
+
     def get_certificate(self, instance_name):
         cert = self.client.kv.get(self._ssl_cert_key(instance_name))[1]
         key = self.client.kv.get(self._ssl_key_key(instance_name))[1]
@@ -88,10 +92,15 @@ class ConsulManager(object):
             location_key = path.replace("/", "___")
         return self._key(instance_name, "locations/" + location_key)
 
-    def _block_key(self, instance_name, block_name):
+    def _block_key(self, instance_name, block_name=None):
         block_key = "ROOT"
-        return self._key(instance_name, "blocks/%s/%s" % (block_name,
-                                                          block_key))
+        if block_name:
+            block_path_key = self._key(instance_name,
+                                       "blocks/%s/%s" % (block_name,
+                                                         block_key))
+        else:
+            block_path_key = self._key(instance_name, "blocks")
+        return block_path_key
 
     def _key(self, instance_name, suffix=None):
         key = "{}/{}".format(self.service_name, instance_name)

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -188,6 +188,14 @@ class Manager(object):
         self.consul_manager.write_location(name, path, destination=destination,
                                            content=content)
 
+    def add_block(self, name, block_name, content):
+        self._ensure_ready(name)
+        block_name = block_name.strip()
+        lb = LoadBalancer.find(name)
+        if lb is None:
+            raise storage.InstanceNotFoundError()
+        self.consul_manager.write_block(name, block_name, content)
+
     def delete_route(self, name, path):
         self._ensure_ready(name)
         path = path.strip()

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -230,6 +230,14 @@ class Manager(object):
             raise storage.InstanceNotFoundError()
         self.consul_manager.remove_block(name, block_name)
 
+    def list_blocks(self, name):
+        self._ensure_ready(name)
+        lb = LoadBalancer.find(name)
+        if lb is None:
+            raise storage.InstanceNotFoundError()
+        blocks = self.consul_manager.list_blocks(name)
+        return [block['Value'] for block in blocks[1]]
+
     def _ensure_ready(self, name):
         task = self.storage.find_task(name)
         if task:

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -188,14 +188,6 @@ class Manager(object):
         self.consul_manager.write_location(name, path, destination=destination,
                                            content=content)
 
-    def add_block(self, name, block_name, content):
-        self._ensure_ready(name)
-        block_name = block_name.strip()
-        lb = LoadBalancer.find(name)
-        if lb is None:
-            raise storage.InstanceNotFoundError()
-        self.consul_manager.write_block(name, block_name, content)
-
     def delete_route(self, name, path):
         self._ensure_ready(name)
         path = path.strip()
@@ -221,6 +213,22 @@ class Manager(object):
             if self.nginx_manager.purge_location(host.dns_name, path):
                 purged_hosts += 1
         return purged_hosts
+
+    def add_block(self, name, block_name, content):
+        self._ensure_ready(name)
+        block_name = block_name.strip()
+        lb = LoadBalancer.find(name)
+        if lb is None:
+            raise storage.InstanceNotFoundError()
+        self.consul_manager.write_block(name, block_name, content)
+
+    def delete_block(self, name, block_name):
+        self._ensure_ready(name)
+        block_name = block_name.strip()
+        lb = LoadBalancer.find(name)
+        if lb is None:
+            raise storage.InstanceNotFoundError()
+        self.consul_manager.remove_block(name, block_name)
 
     def _ensure_ready(self, name):
         task = self.storage.find_task(name)

--- a/rpaas/plugin.py
+++ b/rpaas/plugin.py
@@ -276,7 +276,7 @@ def get_block_args(args):
     parser.add_argument("-i", "--instance", required=True, help="Instance name")
     parser.add_argument("-b", "--block_name", required=False, help="Block in nginx", type=nginx_block)
     parser.add_argument("-c", "--content", required=False,
-                        help="(advanced) raw nginx block content")
+                        help="Raw nginx block content")
     parsed = parser.parse_args(args)
     if parsed.action == 'add' and (not parsed.block_name or not parsed.content):
         sys.stderr.write("block_name and content are required\n")

--- a/tests/managers.py
+++ b/tests/managers.py
@@ -14,6 +14,7 @@ class FakeInstance(object):
         self.plan = plan
         self.bound = []
         self.routes = {}
+        self.blocks = {}
 
     def bind(self, app_host):
         self.bound.append(app_host)
@@ -99,6 +100,10 @@ class FakeManager(object):
     def list_routes(self, name):
         _, instance = self.find_instance(name)
         return instance.routes
+
+    def add_block(self, name, block_name, content):
+        _, instance = self.find_instance(name)
+        instance.blocks[block_name] = {'content': content}
 
     def purge_location(self, name, path):
         _, instance = self.find_instance(name)

--- a/tests/managers.py
+++ b/tests/managers.py
@@ -109,6 +109,10 @@ class FakeManager(object):
         _, instance = self.find_instance(name)
         del instance.blocks[block_name]
 
+    def list_blocks(self, name):
+        _, instance = self.find_instance(name)
+        return instance.blocks
+
     def purge_location(self, name, path):
         _, instance = self.find_instance(name)
         return 4

--- a/tests/managers.py
+++ b/tests/managers.py
@@ -105,6 +105,10 @@ class FakeManager(object):
         _, instance = self.find_instance(name)
         instance.blocks[block_name] = {'content': content}
 
+    def delete_block(self, name, block_name):
+        _, instance = self.find_instance(name)
+        del instance.blocks[block_name]
+
     def purge_location(self, name, path):
         _, instance = self.find_instance(name)
         return 4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -442,3 +442,12 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(200, resp.status_code)
         _, instance = self.manager.find_instance("someapp")
         self.assertIsNone(instance.blocks.get('server'))
+
+    def test_list_blocks(self):
+        instance = self.manager.new_instance("someapp")
+        instance.blocks['http'] = 'true.com'
+        resp = self.api.get("/resources/someapp/block")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual("application/json", resp.mimetype)
+        data = json.loads(resp.data)
+        self.assertDictEqual({"http": "true.com"}, data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -445,9 +445,10 @@ class APITestCase(unittest.TestCase):
 
     def test_list_blocks(self):
         instance = self.manager.new_instance("someapp")
-        instance.blocks['http'] = 'true.com'
+        instance.blocks['http'] = 'https'
+        instance.blocks['server'] = 'true.com'
         resp = self.api.get("/resources/someapp/block")
         self.assertEqual(200, resp.status_code)
         self.assertEqual("application/json", resp.mimetype)
         data = json.loads(resp.data)
-        self.assertDictEqual({"http": "true.com"}, data)
+        self.assertDictEqual({"server": "true.com", "http": "https"}, data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -435,9 +435,9 @@ class APITestCase(unittest.TestCase):
     def test_delete_block(self):
         instance = self.manager.new_instance("someapp")
         instance.blocks['server'] = 'true.com'
-        resp = self.api.delete("/resources/someapp/block", data={
-            'block_name': 'server'
-        }, headers={'Content-Type': 'application/x-www-form-urlencoded'})
+        resp = self.api.delete("/resources/someapp/block/server", headers={
+            'Content-Type': 'application/x-www-form-urlencoded'
+        })
         self.assertEqual(200, resp.status_code)
         _, instance = self.manager.find_instance("someapp")
         self.assertIsNone(instance.blocks.get('server'))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -395,3 +395,40 @@ class APITestCase(unittest.TestCase):
 
     def delete_auth_env(self):
         del os.environ["API_USERNAME"], os.environ["API_PASSWORD"]
+
+    def test_add_block(self):
+        self.manager.new_instance('someapp')
+        resp = self.api.post('/resource/someapp/block', data={
+            'content': 'something',
+            'block_name': 'http'
+        })
+        self.assertEqual(201, resp.status_code)
+        _, instance = self.manager.find_instance('someapp')
+        self.assertDictEqual(instance.blocks.get('http'), {
+            'content': u'something',
+        })
+
+    def test_add_block_without_content(self):
+        self.manager.new_instance('someapp')
+        resp = self.api.post('/resource/someapp/block', data={
+            'content': None,
+            'block_name': 'http'
+        })
+        self.assertEqual(400, resp.status_code)
+
+
+    def test_add_block_without_block_name(self):
+        self.manager.new_instance('someapp')
+        resp = self.api.post('/resource/someapp/block', data={
+            'content': 'something',
+            'block_name': None
+        })
+        self.assertEqual(400, resp.status_code)
+
+    def test_add_block_not_server_http(self):
+        self.manager.new_instance('someapp')
+        resp = self.api.post('/resource/someapp/block', data={
+            'content': 'something',
+            'block_name': 'location'
+        })
+        self.assertEqual(400, resp.status_code)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -416,7 +416,6 @@ class APITestCase(unittest.TestCase):
         })
         self.assertEqual(400, resp.status_code)
 
-
     def test_add_block_without_block_name(self):
         self.manager.new_instance('someapp')
         resp = self.api.post('/resource/someapp/block', data={

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -432,3 +432,13 @@ class APITestCase(unittest.TestCase):
             'block_name': 'location'
         })
         self.assertEqual(400, resp.status_code)
+
+    def test_delete_block(self):
+        instance = self.manager.new_instance("someapp")
+        instance.blocks['server'] = 'true.com'
+        resp = self.api.delete("/resources/someapp/block", data={
+            'block_name': 'server'
+        }, headers={'Content-Type': 'application/x-www-form-urlencoded'})
+        self.assertEqual(200, resp.status_code)
+        _, instance = self.manager.find_instance("someapp")
+        self.assertIsNone(instance.blocks.get('server'))

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -143,3 +143,16 @@ class ConsulManagerTestCase(unittest.TestCase):
         self.manager.remove_location("myrpaas", "/admin/app_sites/")
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/___admin___app_sites___")
         self.assertIsNone(item[1])
+
+    def test_remove_block_server_root(self):
+        self.manager.write_block("myrpaas", "server",
+                                 "something nice in server")
+        self.manager.remove_block("myrpaas", "server")
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/blocks/server/ROOT")
+        self.assertIsNone(item[1])
+
+    def test_remove_block_http_root(self):
+        self.manager.write_block("myrpaas", "http", "something nice in http")
+        self.manager.remove_block("myrpaas", "http")
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/blocks/http/ROOT")
+        self.assertIsNone(item[1])

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -90,6 +90,18 @@ class ConsulManagerTestCase(unittest.TestCase):
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/___admin___app_sites___")
         self.assertEqual("something nice", item[1]["Value"])
 
+    def test_write_block_http_content(self):
+        self.manager.write_block("myrpaas", "http",
+                                 content=" something nice in http         \n")
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/blocks/http/ROOT")
+        self.assertEqual("something nice in http", item[1]["Value"])
+
+    def test_write_block_server_content(self):
+        self.manager.write_block("myrpaas", "server",
+                                 content=" something nice in server         \n")
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/blocks/server/ROOT")
+        self.assertEqual("something nice in server", item[1]["Value"])
+
     def test_get_certificate(self):
         origin_cert, origin_key = "cert", "key"
         self.consul.kv.put("test-suite-rpaas/myrpaas/ssl/cert", origin_cert)

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -156,3 +156,19 @@ class ConsulManagerTestCase(unittest.TestCase):
         self.manager.remove_block("myrpaas", "http")
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/blocks/http/ROOT")
         self.assertIsNone(item[1])
+
+    def test_list_one_block(self):
+        self.manager.write_block("myrpaas", "server",
+                                 "something nice in server")
+        items = self.manager.list_blocks("myrpaas")
+        self.assertEqual(1, len(items[1]))
+        self.assertEqual("something nice in server", items[1][0]["Value"])
+
+    def test_list_block(self):
+        self.manager.write_block("myrpaas", "server",
+                                 "something nice in server")
+        self.manager.write_block("myrpaas", "http", "something nice in http")
+        items = self.manager.list_blocks("myrpaas")
+        self.assertEqual(2, len(items[1]))
+        self.assertEqual("something nice in http", items[1][0]["Value"])
+        self.assertEqual("something nice in server", items[1][1]["Value"])

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -677,6 +677,36 @@ content = location /x {
         manager.consul_manager.remove_block.assert_called_with("inst", "http")
 
     @mock.patch("rpaas.manager.LoadBalancer")
+    def test_list_block(self, LoadBalancer):
+        lb = LoadBalancer.find.return_value
+        lb.hosts = [mock.Mock(), mock.Mock()]
+
+        manager = Manager(self.config)
+        manager.consul_manager = mock.Mock()
+        manager.consul_manager.list_blocks.return_value = [
+            None, [{'Value': 'my content'}, {'Value': 'my content 2'}]
+        ]
+        manager.list_blocks("inst")
+
+        LoadBalancer.find.assert_called_with("inst")
+        manager.consul_manager.list_blocks.assert_called_with("inst")
+
+    @mock.patch("rpaas.manager.LoadBalancer")
+    def test_list_block_with_one_content(self, LoadBalancer):
+        lb = LoadBalancer.find.return_value
+        lb.hosts = [mock.Mock(), mock.Mock()]
+
+        manager = Manager(self.config)
+        manager.consul_manager = mock.Mock()
+        manager.consul_manager.list_blocks.return_value = [
+            None, [{'Value': 'my content'}]
+        ]
+        manager.list_blocks("inst")
+
+        LoadBalancer.find.assert_called_with("inst")
+        manager.consul_manager.list_blocks.assert_called_with("inst")
+
+    @mock.patch("rpaas.manager.LoadBalancer")
     def test_purge_location(self, LoadBalancer):
         lb = LoadBalancer.find.return_value
         lb.hosts = [mock.Mock(), mock.Mock()]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -652,7 +652,6 @@ content = location /x {
 
     @mock.patch("rpaas.manager.LoadBalancer")
     def test_add_block_with_content(self, LoadBalancer):
-        self.storage.store_binding("inst", "app.host.com")
         lb = LoadBalancer.find.return_value
         lb.hosts = [mock.Mock(), mock.Mock()]
 
@@ -664,6 +663,18 @@ content = location /x {
         manager.consul_manager.write_block.assert_called_with(
             "inst", "server", "location /x { something; }"
         )
+
+    @mock.patch("rpaas.manager.LoadBalancer")
+    def test_delete_block(self, LoadBalancer):
+        lb = LoadBalancer.find.return_value
+        lb.hosts = [mock.Mock(), mock.Mock()]
+
+        manager = Manager(self.config)
+        manager.consul_manager = mock.Mock()
+        manager.delete_block("inst", "http")
+
+        LoadBalancer.find.assert_called_with("inst")
+        manager.consul_manager.remove_block.assert_called_with("inst", "http")
 
     @mock.patch("rpaas.manager.LoadBalancer")
     def test_purge_location(self, LoadBalancer):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -651,6 +651,21 @@ content = location /x {
         LoadBalancer.find.assert_called_with("inst")
 
     @mock.patch("rpaas.manager.LoadBalancer")
+    def test_add_block_with_content(self, LoadBalancer):
+        self.storage.store_binding("inst", "app.host.com")
+        lb = LoadBalancer.find.return_value
+        lb.hosts = [mock.Mock(), mock.Mock()]
+
+        manager = Manager(self.config)
+        manager.consul_manager = mock.Mock()
+        manager.add_block("inst", "server", "location /x { something; }")
+
+        LoadBalancer.find.assert_called_with("inst")
+        manager.consul_manager.write_block.assert_called_with(
+            "inst", "server", "location /x { something; }"
+        )
+
+    @mock.patch("rpaas.manager.LoadBalancer")
     def test_purge_location(self, LoadBalancer):
         lb = LoadBalancer.find.return_value
         lb.hosts = [mock.Mock(), mock.Mock()]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -315,7 +315,6 @@ class TsuruPluginTestCase(unittest.TestCase):
         urlopen.return_value.getcode.return_value = 200
         self.set_envs()
         self.addCleanup(self.delete_envs)
-        path = os.path.join(os.path.dirname(__file__), "testdata", "block_http")
         plugin.block(['add', '-s', 'myservice', '-i', 'myinst', '-b', 'http', '-c', 'lalala'])
         Request.assert_called_with(self.target +
                                    "services/myservice/proxy/myinst?" +
@@ -353,7 +352,8 @@ class TsuruPluginTestCase(unittest.TestCase):
         request = Request.return_value
         urlopen.return_value.getcode.return_value = 200
         urlopen.return_value.read.return_value = '{"_id": "myinst", ' + \
-            '"blocks": [{"block_name": "http", "content": "my content"}, {"block_name": "server", "content": "server content"}]}'
+            '"blocks": [{"block_name": "http", "content": "my content"}, ' + \
+            '{"block_name": "server", "content": "server content"}]}'
         self.set_envs()
         self.addCleanup(self.delete_envs)
         plugin.block(['list', '-s', 'myservice', '-i', 'myinst'])

--- a/tests/testdata/block_http
+++ b/tests/testdata/block_http
@@ -1,0 +1,1 @@
+content


### PR DESCRIPTION
Now plugin can add blocks for nginx rpass config.

We can add a block using:
```
block add -s service -i instance -b (http | server) -c 'content'
```

We can remove a block using:
```
block remove -s service -i instance -b (http | server)
```

We can list all blocks from rpass using:

```
block list -s service -i instance
```
Thank you @cezarsa and https://github.com/kplaube
