### PR TITLE
Implementing restore machine route for async reinstall rpaas instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 python: "2.7"
 install:
   - make deps
-  - curl -LO https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
-  - unzip 0.5.2_linux_amd64.zip
+  - curl -LO https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip
+  - unzip consul_0.5.2_linux_amd64.zip
   - GOMAXPROCS=8 PATH=":$PATH" make start-consul
 script: make test
 services:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ flower: deps
 	celery flower -A rpaas.tasks
 
 start-consul:
-	consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul -config-file etc/consul.conf -node=rpaas-test &
+	consul agent -server -bind 127.0.0.1 -bootstrap-expect 1 -data-dir /tmp/consul -config-file etc/consul.conf -node=rpaas-test &
 	while ! consul info; do sleep 1; done
 
 test: clean_pycs deps

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -5,6 +5,7 @@
 # license that can be found in the LICENSE file.
 
 import copy
+import datetime
 import os
 import socket
 
@@ -77,18 +78,19 @@ class Manager(object):
         if cancel_task:
             try:
                 self._ensure_ready("restore_{}".format(machine))
-            except NotReadyError():
+            except NotReadyError:
                 self.storage.remove_task("restore_{}".format(machine))
                 return
-            raise TaskNotFoundError()
+            raise TaskNotFoundError("Task restore_{} not found for removal".format(machine))
         self._ensure_ready("restore_{}".format(machine))
         lb = LoadBalancer.find(name)
         if lb is None:
             raise storage.InstanceNotFoundError()
         machine_data = self.storage.find_host_id(machine)
         if machine_data is None:
-            raise storage.InstanceMachineNotFoundError()
-        self.storage.store_task("{}_{}".format(name, machine))
+            raise InstanceMachineNotFoundError()
+        self.storage.store_task({"_id": "restore_{}".format(machine), "host": machine,
+                                "instance": name, "created": datetime.datetime.utcnow()})
 
     def bind(self, name, app_host):
         self._ensure_ready(name)
@@ -358,6 +360,10 @@ class SslError(Exception):
 
 
 class TaskNotFoundError(Exception):
+    pass
+
+
+class InstanceMachineNotFoundError(Exception):
     pass
 
 

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -169,8 +169,8 @@ class Manager(object):
 
     def _get_address(self, name):
         task = self.storage.find_task(name)
-        if task:
-            result = tasks.NewInstanceTask().AsyncResult(task["task_id"])
+        if task.count() >= 1:
+            result = tasks.NewInstanceTask().AsyncResult(task[0]["task_id"])
             if result.status in ["FAILURE", "REVOKED"]:
                 return FAILURE
             return PENDING
@@ -265,7 +265,7 @@ class Manager(object):
 
     def _ensure_ready(self, name):
         task = self.storage.find_task(name)
-        if task:
+        if task.count() >= 1:
             raise NotReadyError("Async task still running")
 
     def _check_dns(self, name, domain):

--- a/rpaas/scheduler.py
+++ b/rpaas/scheduler.py
@@ -1,0 +1,57 @@
+# Copyright 2016 rpaas authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+import datetime
+import os
+import threading
+
+import redis
+
+from rpaas import tasks
+
+DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+class JobScheduler(threading.Thread):
+    """
+    Generic Job Scheduler
+
+    It should run on the API role, as it depends on environment variables for
+    working.
+    """
+
+    def __init__(self, config=None, *args, **kwargs):
+        super(JobScheduler, self).__init__(*args, **kwargs)
+        self.daemon = True
+        self.config = config or dict(os.environ)
+        self.interval = int(self.config.get("JOB_SCHEDULER_RUN_INTERVAL", 30))
+        self.last_run_key = self.config.get("JOB_SCHEDULER_LAST_RUN_KEY", "job_scheduler:last_run")
+        self.conn = redis.StrictRedis(host=tasks.redis_host, port=tasks.redis_port,
+                                      password=tasks.redis_password)
+
+    def try_lock(self):
+        interval_delta = datetime.timedelta(seconds=self.interval)
+        with self.conn.pipeline() as pipe:
+            try:
+                now = datetime.datetime.utcnow()
+                pipe.watch(self.last_run_key)
+                last_run = pipe.get(self.last_run_key)
+                if last_run:
+                    last_run_date = datetime.datetime.strptime(last_run, DATETIME_FORMAT)
+                    if now - last_run_date < interval_delta:
+                        pipe.unwatch()
+                        return False
+                pipe.multi()
+                pipe.set(self.last_run_key, now.strftime(DATETIME_FORMAT))
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                return False
+
+    def run(self):
+        raise NotImplementedError()
+
+    def stop(self):
+        self.running = False
+        self.join()

--- a/rpaas/scheduler.py
+++ b/rpaas/scheduler.py
@@ -5,6 +5,7 @@
 import datetime
 import os
 import threading
+import time
 
 import redis
 
@@ -55,3 +56,23 @@ class JobScheduler(threading.Thread):
     def stop(self):
         self.running = False
         self.join()
+
+
+class RestoreMachine(JobScheduler):
+    """
+    RestoreMachine is a thread for execute restore machine jobs.
+
+    """
+
+    def __init__(self, config=None, *args, **kwargs):
+        super(RestoreMachine, self).__init__(*args, **kwargs)
+        self.config = config or dict(os.environ)
+        self.interval = int(self.config.get("RESTORE_MACHINE_RUN_INTERVAL", 30))
+        self.last_run_key = self.config.get("RESTORE_MACHINE_LAST_RUN_KEY", "restore_machine:last_run")
+
+    def run(self):
+        self.running = True
+        while self.running:
+            if self.try_lock():
+                tasks.RestoreMachineTask().delay(self.config)
+            time.sleep(self.interval / 2)

--- a/rpaas/ssl_plugins/le_renewer.py
+++ b/rpaas/ssl_plugins/le_renewer.py
@@ -2,19 +2,13 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-import datetime
-import os
-import threading
 import time
+import os
 
-import redis
-
-from rpaas import tasks
-
-DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+from rpaas import tasks, scheduler
 
 
-class LeRenewer(threading.Thread):
+class LeRenewer(scheduler.JobScheduler):
     """
     LeRenewer is a thread that prevents certificate LE expiration. It just adds
     a task to the queue, so workers can properly do the job.
@@ -25,12 +19,9 @@ class LeRenewer(threading.Thread):
 
     def __init__(self, config=None, *args, **kwargs):
         super(LeRenewer, self).__init__(*args, **kwargs)
-        self.daemon = True
         self.config = config or dict(os.environ)
         self.interval = int(self.config.get("LE_RENEWER_RUN_INTERVAL", 86400))
         self.last_run_key = self.config.get("LE_RENEWER_LAST_RUN_KEY", "le_renewer:last_run")
-        self.conn = redis.StrictRedis(host=tasks.redis_host, port=tasks.redis_port,
-                                      password=tasks.redis_password)
 
     def run(self):
         self.running = True
@@ -38,26 +29,3 @@ class LeRenewer(threading.Thread):
             if self.try_lock():
                 tasks.RenewCertsTask().delay(self.config)
             time.sleep(self.interval / 2)
-
-    def try_lock(self):
-        interval_delta = datetime.timedelta(seconds=self.interval)
-        with self.conn.pipeline() as pipe:
-            try:
-                now = datetime.datetime.utcnow()
-                pipe.watch(self.last_run_key)
-                last_run = pipe.get(self.last_run_key)
-                if last_run:
-                    last_run_date = datetime.datetime.strptime(last_run, DATETIME_FORMAT)
-                    if now - last_run_date < interval_delta:
-                        pipe.unwatch()
-                        return False
-                pipe.multi()
-                pipe.set(self.last_run_key, now.strftime(DATETIME_FORMAT))
-                pipe.execute()
-                return True
-            except redis.WatchError:
-                return False
-
-    def stop(self):
-        self.running = False
-        self.join()

--- a/rpaas/storage.py
+++ b/rpaas/storage.py
@@ -43,18 +43,23 @@ class MongoDBStorage(storage.MongoDBStorage):
 
     def store_task(self, name):
         try:
-            self.db[self.tasks_collection].insert({'_id': name})
+            if name.__class__ is dict:
+                self.db[self.tasks_collection].insert(name)
+            else:
+                self.db[self.tasks_collection].insert({'_id': name})
         except pymongo.errors.DuplicateKeyError:
             raise DuplicateError(name)
 
-    def remove_task(self, name):
-        self.db[self.tasks_collection].remove({'_id': name})
+    def remove_task(self, query):
+        self.db[self.tasks_collection].remove(query)
 
     def update_task(self, name, task_id):
         self.db[self.tasks_collection].update({'_id': name}, {'$set': {'task_id': task_id}})
 
-    def find_task(self, name):
-        return self.db[self.tasks_collection].find_one({'_id': name})
+    def find_task(self, query):
+        if query.__class__ is dict:
+            return self.db[self.tasks_collection].find(query)
+        return self.db[self.tasks_collection].find_one(query)
 
     def store_instance_metadata(self, instance_name, **data):
         data['_id'] = instance_name
@@ -63,6 +68,9 @@ class MongoDBStorage(storage.MongoDBStorage):
 
     def find_instance_metadata(self, instance_name):
         return self.db[self.instance_metadata_collection].find_one({'_id': instance_name})
+
+    def find_host_id(self, name):
+        return self.db[self.hosts_collection].find_one({'dns_name': name})
 
     def remove_instance_metadata(self, instance_name):
         self.db[self.instance_metadata_collection].remove({'_id': instance_name})

--- a/rpaas/storage.py
+++ b/rpaas/storage.py
@@ -53,8 +53,11 @@ class MongoDBStorage(storage.MongoDBStorage):
     def remove_task(self, query):
         self.db[self.tasks_collection].remove(query)
 
-    def update_task(self, name, task_id):
-        self.db[self.tasks_collection].update({'_id': name}, {'$set': {'task_id': task_id}})
+    def update_task(self, name, task_id_or_spec):
+        if task_id_or_spec.__class__ is dict:
+            self.db[self.tasks_collection].update({'_id': name}, {'$set': task_id_or_spec})
+        else:
+            self.db[self.tasks_collection].update({'_id': name}, {'$set': {'task_id': task_id_or_spec}})
 
     def find_task(self, query):
         if query.__class__ is dict:

--- a/rpaas/storage.py
+++ b/rpaas/storage.py
@@ -62,7 +62,8 @@ class MongoDBStorage(storage.MongoDBStorage):
     def find_task(self, query):
         if isinstance(query, dict):
             return self.db[self.tasks_collection].find(query)
-        return self.db[self.tasks_collection].find_one(query)
+        else:
+            return self.db[self.tasks_collection].find({"_id": query})
 
     def store_instance_metadata(self, instance_name, **data):
         data['_id'] = instance_name

--- a/rpaas/storage.py
+++ b/rpaas/storage.py
@@ -43,7 +43,7 @@ class MongoDBStorage(storage.MongoDBStorage):
 
     def store_task(self, name):
         try:
-            if name.__class__ is dict:
+            if isinstance(name, dict):
                 self.db[self.tasks_collection].insert(name)
             else:
                 self.db[self.tasks_collection].insert({'_id': name})
@@ -54,13 +54,13 @@ class MongoDBStorage(storage.MongoDBStorage):
         self.db[self.tasks_collection].remove(query)
 
     def update_task(self, name, task_id_or_spec):
-        if task_id_or_spec.__class__ is dict:
+        if isinstance(task_id_or_spec, dict):
             self.db[self.tasks_collection].update({'_id': name}, {'$set': task_id_or_spec})
         else:
             self.db[self.tasks_collection].update({'_id': name}, {'$set': {'task_id': task_id_or_spec}})
 
     def find_task(self, query):
-        if query.__class__ is dict:
+        if isinstance(query, dict):
             return self.db[self.tasks_collection].find(query)
         return self.db[self.tasks_collection].find_one(query)
 

--- a/rpaas/tasks.py
+++ b/rpaas/tasks.py
@@ -137,6 +137,9 @@ class ScaleInstanceTask(BaseManagerTask):
         finally:
             self.storage.remove_task(name)
 
+#class RestoreMachineTask(BaseManagerTask):
+
+
 
 class DownloadCertTask(BaseManagerTask):
 

--- a/rpaas/tasks.py
+++ b/rpaas/tasks.py
@@ -142,16 +142,26 @@ class RestoreMachineTask(BaseManagerTask):
 
     def run(self, config):
         self.init_config(config)
+        retry_failure_delay = int(self.config.get("RESTORE_MACHINE_FAILURE_DELAY", 5))
+        retry_failure_query = {"_id": {"$regex": "restore_.+"}, "last_attempt": {"$ne": None}}
+        failure_instances = set()
+        for task in self.storage.find_task(retry_failure_query):
+            retry_failure = task['last_attempt'] + datetime.timedelta(minutes=retry_failure_delay)
+            if (retry_failure >= datetime.datetime.utcnow()):
+                failure_instances.add(task['instance'])
         restore_delay = int(self.config.get("RESTORE_MACHINE_DELAY", 5))
         created_in = datetime.datetime.utcnow() - datetime.timedelta(minutes=restore_delay)
         query = {"_id": {"$regex": "restore_.+"}, "created": {"$lte": created_in}}
         for task in self.storage.find_task(query):
             try:
-                host = self.storage.find_host_id(task['host'])
-                Host.from_dict({"_id": host['_id'], "dns_name": task['host'], "manager": host['manager']},
-                               conf=config).restore()
-            finally:
-                self.storage.remove_task({"_id": task['_id']})
+                if task['instance'] not in failure_instances:
+                    host = self.storage.find_host_id(task['host'])
+                    Host.from_dict({"_id": host['_id'], "dns_name": task['host'], "manager": host['manager']},
+                                   conf=config).restore()
+                    self.storage.remove_task({"_id": task['_id']})
+            except Exception as e:
+                self.storage.update_task(task['_id'], {"last_attempt": datetime.datetime.utcnow()})
+                raise e
 
 
 class DownloadCertTask(BaseManagerTask):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "requests==2.4.3",
         "gevent==1.1b6",
         "gunicorn==0.17.2",
-        "tsuru-hm==0.4.1",
+        "tsuru-hm==0.5.1",
         "celery[redis]",
         "flower==0.7.3",
         "GloboNetworkAPI==0.2.2",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "requests==2.4.3",
         "gevent==1.1b6",
         "gunicorn==0.17.2",
-        "tsuru-hm==0.5.1",
+        "tsuru-hm==0.5.2",
         "celery[redis]",
         "flower==0.7.3",
         "GloboNetworkAPI==0.2.2",

--- a/tests/managers.py
+++ b/tests/managers.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from rpaas import storage
+from rpaas import storage, manager
 
 
 class FakeInstance(object):
@@ -119,3 +119,10 @@ class FakeManager(object):
 
     def reset(self):
         self.instances = []
+
+    def restore_machine_instance(self, name, machine, cancel_task=False):
+        index, instance = self.find_instance(name)
+        if index < 0:
+            raise storage.InstanceNotFoundError()
+        if machine != 'foo':
+            raise manager.InstanceMachineNotFoundError()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -290,6 +290,72 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(401, resp.status_code)
         self.assertEqual("you do not have access to this resource", resp.data)
 
+    def test_restore_machine_disabled(self):
+        if "RUN_RESTORE_MACHINE" in os.environ:
+            del os.environ["RUN_RESTORE_MACHINE"]
+        resp = self.api.post("/resources/someapp/restore_machine", data={"machine": "foo"})
+        self.assertEqual(412, resp.status_code)
+        self.assertEqual("Restore machine not enabled", resp.data)
+
+    def test_restore_machine_missing_machine(self):
+        os.environ["RUN_RESTORE_MACHINE"] = "1"
+        resp = self.api.post("/resources/someapp/restore_machine")
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual("missing machine name", resp.data)
+
+    def test_restore_machine_instance_not_found(self):
+        os.environ["RUN_RESTORE_MACHINE"] = "1"
+        resp = self.api.post("/resources/otherapp/restore_machine", data={"machine": "bar"})
+        self.assertEqual(404, resp.status_code)
+        self.assertEqual("Instance not found", resp.data)
+
+    def test_restore_machine_instance_machine_not_found(self):
+        os.environ["RUN_RESTORE_MACHINE"] = "1"
+        self.manager.new_instance("someapp")
+        resp = self.api.post("/resources/someapp/restore_machine", data={"machine": "bar"})
+        self.assertEqual(404, resp.status_code)
+        self.assertEqual("Instance machine not found", resp.data)
+
+    def test_restore_machine_success(self):
+        os.environ["RUN_RESTORE_MACHINE"] = "1"
+        self.manager.new_instance("someapp")
+        resp = self.api.post("/resources/someapp/restore_machine", data={"machine": "foo"})
+        self.assertEqual(201, resp.status_code)
+        self.assertEqual("", resp.data)
+
+    def test_cancel_restore_machine_disabled(self):
+        if "RUN_RESTORE_MACHINE" in os.environ:
+            del os.environ["RUN_RESTORE_MACHINE"]
+        resp = self.api.delete("/resources/someapp/restore_machine", data={"machine": "foo"})
+        self.assertEqual(412, resp.status_code)
+        self.assertEqual("Restore machine not enabled", resp.data)
+
+    def test_cancel_restore_machine_missing_machine(self):
+        os.environ["RUN_RESTORE_MACHINE"] = "1"
+        resp = self.api.delete("/resources/someapp/restore_machine")
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual("missing machine name", resp.data)
+
+    def test_cancel_restore_machine_instance_not_found(self):
+        os.environ["RUN_RESTORE_MACHINE"] = "1"
+        resp = self.api.delete("/resources/otherapp/restore_machine", data={"machine": "bar"})
+        self.assertEqual(404, resp.status_code)
+        self.assertEqual("Instance not found", resp.data)
+
+    def test_cancel_restore_machine_instance_machine_not_found(self):
+        os.environ["RUN_RESTORE_MACHINE"] = "1"
+        self.manager.new_instance("someapp")
+        resp = self.api.delete("/resources/someapp/restore_machine", data={"machine": "bar"})
+        self.assertEqual(404, resp.status_code)
+        self.assertEqual("Instance machine not found", resp.data)
+
+    def test_cancel_restore_machine_success(self):
+        os.environ["RUN_RESTORE_MACHINE"] = "1"
+        self.manager.new_instance("someapp")
+        resp = self.api.delete("/resources/someapp/restore_machine", data={"machine": "foo"})
+        self.assertEqual(201, resp.status_code)
+        self.assertEqual("", resp.data)
+
     def test_plugin(self):
         expected = inspect.getsource(plugin)
         resp = self.api.get("/plugin")

--- a/tests/test_machine_restore.py
+++ b/tests/test_machine_restore.py
@@ -1,0 +1,83 @@
+# Copyright 2015 rpaas authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+import datetime
+import time
+import unittest
+import redis
+from freezegun import freeze_time
+from mock import patch, call
+from rpaas import storage, tasks
+from rpaas import scheduler
+from hm import managers, log
+from hm.model.host import Host
+
+tasks.app.conf.CELERY_ALWAYS_EAGER = True
+
+
+class FakeManager(managers.BaseManager):
+
+    host_id = 0
+    hosts = ['10.2.2.2', '10.1.1.1']
+
+    def __init__(self, config=None):
+        super(FakeManager, self).__init__(config)
+
+    def create_host(self, name=None, alternative_id=0):
+        id = self.host_id
+        FakeManager.host_id += 1
+        return Host(id=id, dns_name=FakeManager.hosts.pop(), alternative_id=alternative_id)
+
+    def restore_host(self, id):
+        log.logging.info("Machine {} restored".format(id))
+
+    def destroy_host(self, id):
+        log.logging.info("Machine {} destroyed".format(id))
+
+
+managers.register('fake', FakeManager)
+
+
+@freeze_time("2016-02-03 12:00:00")
+class RestoreMachineTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {
+            "MONGO_DATABASE": "machine_restore_test",
+            "RPAAS_SERVICE_NAME": "test_rpaas_machine_restore",
+            "RESTORE_MACHINE_RUN_INTERVAL": 2,
+            "HOST_MANAGER": "fake"
+        }
+
+        self.storage = storage.MongoDBStorage(self.config)
+        colls = self.storage.db.collection_names(False)
+        for coll in colls:
+            self.storage.db.drop_collection(coll)
+
+        now = datetime.datetime.utcnow()
+        tasks = [
+            {"_id": "restore_10.1.1.1", "host": "10.1.1.1",
+             "created": now - datetime.timedelta(minutes=8)},
+            {"_id": "restore_10.2.2.2", "host": "10.2.2.2",
+             "created": now - datetime.timedelta(minutes=3)}
+        ]
+
+        for task in tasks:
+            Host.create("fake", "my-group", self.config)
+            self.storage.store_task(task)
+
+        redis.StrictRedis().delete("restore_machine:last_run")
+
+    def tearDown(self):
+        self.storage.db[self.storage.tasks_collection].remove()
+        self.storage.db[self.storage.hosts_collection].remove()
+
+    @patch("hm.log.logging")
+    def test_restore_machine(self, log):
+        restorer = scheduler.RestoreMachine(self.config)
+        restorer.start()
+        time.sleep(1)
+        restorer.stop()
+        self.assertIsNone(self.storage.find_task("restore_10.1.1.1"))
+        self.assertEqual(log.info.call_args, call("Machine 0 restored"))

--- a/tests/test_machine_restore.py
+++ b/tests/test_machine_restore.py
@@ -16,10 +16,15 @@ from hm.model.host import Host
 tasks.app.conf.CELERY_ALWAYS_EAGER = True
 
 
+class RestoreHostError(Exception):
+    pass
+
+
 class FakeManager(managers.BaseManager):
 
     host_id = 0
-    hosts = ['10.2.2.2', '10.1.1.1']
+    hosts = []
+    fail_ids = []
 
     def __init__(self, config=None):
         super(FakeManager, self).__init__(config)
@@ -27,9 +32,11 @@ class FakeManager(managers.BaseManager):
     def create_host(self, name=None, alternative_id=0):
         id = self.host_id
         FakeManager.host_id += 1
-        return Host(id=id, dns_name=FakeManager.hosts.pop(), alternative_id=alternative_id)
+        return Host(id=id, dns_name=FakeManager.hosts.pop(0), alternative_id=alternative_id)
 
     def restore_host(self, id):
+        if id in self.fail_ids:
+            raise RestoreHostError("iaas restore error")
         log.logging.info("Machine {} restored".format(id))
 
     def destroy_host(self, id):
@@ -57,14 +64,22 @@ class RestoreMachineTestCase(unittest.TestCase):
 
         now = datetime.datetime.utcnow()
         tasks = [
-            {"_id": "restore_10.1.1.1", "host": "10.1.1.1",
+            {"_id": "restore_10.1.1.1", "host": "10.1.1.1", "instance": "foo",
              "created": now - datetime.timedelta(minutes=8)},
-            {"_id": "restore_10.2.2.2", "host": "10.2.2.2",
-             "created": now - datetime.timedelta(minutes=3)}
+            {"_id": "restore_10.2.2.2", "host": "10.2.2.2", "instance": "bar",
+             "created": now - datetime.timedelta(minutes=3)},
+            {"_id": "restore_10.3.3.3", "host": "10.3.3.3", "instance": "foo",
+             "created": now - datetime.timedelta(minutes=5)},
+            {"_id": "restore_10.4.4.4", "host": "10.4.4.4", "instance": "foo",
+             "created": now - datetime.timedelta(minutes=10)},
+            {"_id": "restore_10.5.5.5", "host": "10.5.5.5", "instance": "bar",
+             "created": now - datetime.timedelta(minutes=15)},
         ]
+        FakeManager.host_id = 0
+        FakeManager.hosts = ['10.1.1.1', '10.2.2.2', '10.3.3.3', '10.4.4.4', '10.5.5.5']
 
         for task in tasks:
-            Host.create("fake", "my-group", self.config)
+            Host.create("fake", task['instance'], self.config)
             self.storage.store_task(task)
 
         redis.StrictRedis().delete("restore_machine:last_run")
@@ -74,10 +89,44 @@ class RestoreMachineTestCase(unittest.TestCase):
         self.storage.db[self.storage.hosts_collection].remove()
 
     @patch("hm.log.logging")
-    def test_restore_machine(self, log):
+    def test_restore_machine_success(self, log):
+        FakeManager.fail_ids = []
         restorer = scheduler.RestoreMachine(self.config)
         restorer.start()
         time.sleep(1)
         restorer.stop()
-        self.assertIsNone(self.storage.find_task("restore_10.1.1.1"))
-        self.assertEqual(log.info.call_args, call("Machine 0 restored"))
+        self.assertEqual(log.info.call_args_list, [call("Machine 0 restored"), call("Machine 2 restored"),
+                                                   call("Machine 3 restored"), call("Machine 4 restored")])
+
+    @patch("hm.log.logging")
+    def test_restore_machine_iaas_fail(self, log):
+        FakeManager.fail_ids = [2]
+        restorer = scheduler.RestoreMachine(self.config)
+        restorer.start()
+        time.sleep(1)
+        restorer.stop()
+        tasks = [task['_id'] for task in self.storage.find_task({"_id": {"$regex": "restore_.+"}})]
+        self.assertListEqual(['restore_10.2.2.2', 'restore_10.3.3.3',
+                              'restore_10.4.4.4', 'restore_10.5.5.5'], tasks)
+        self.assertEqual(log.info.call_args_list, [call("Machine 0 restored")])
+        log.reset_mock()
+        redis.StrictRedis().delete("restore_machine:last_run")
+        restorer = scheduler.RestoreMachine(self.config)
+        restorer.start()
+        time.sleep(1)
+        restorer.stop()
+        tasks = [task['_id'] for task in self.storage.find_task({"_id": {"$regex": "restore_.+"}})]
+        self.assertEqual(log.info.call_args_list, [call("Machine 4 restored")])
+        self.assertListEqual(['restore_10.2.2.2', 'restore_10.3.3.3', 'restore_10.4.4.4'], tasks)
+        log.reset_mock()
+        redis.StrictRedis().delete("restore_machine:last_run")
+        FakeManager.fail_ids = []
+        with freeze_time("2016-02-03 12:06:00"):
+            restorer = scheduler.RestoreMachine(self.config)
+            restorer.start()
+            time.sleep(1)
+            restorer.stop()
+            tasks = [task['_id'] for task in self.storage.find_task({"_id": {"$regex": "restore_.+"}})]
+            self.assertEqual(log.info.call_args_list, [call("Machine 1 restored"), call("Machine 2 restored"),
+                                                       call("Machine 3 restored")])
+            self.assertListEqual(tasks, [])

--- a/tests/test_machine_restore.py
+++ b/tests/test_machine_restore.py
@@ -97,6 +97,20 @@ class RestoreMachineTestCase(unittest.TestCase):
         restorer.stop()
         self.assertEqual(log.info.call_args_list, [call("Machine 0 restored"), call("Machine 2 restored"),
                                                    call("Machine 3 restored"), call("Machine 4 restored")])
+        tasks = [task['_id'] for task in self.storage.find_task({"_id": {"$regex": "restore_.+"}})]
+        self.assertListEqual(tasks, ['restore_10.2.2.2'])
+
+    @patch("hm.log.logging")
+    def test_restore_machine_dry_mode(self, log):
+        FakeManager.fail_ids = []
+        self.config['RESTORE_MACHINE_DRY_MODE'] = 1
+        restorer = scheduler.RestoreMachine(self.config)
+        restorer.start()
+        time.sleep(1)
+        restorer.stop()
+        self.assertListEqual(log.info.call_args_list, [])
+        tasks = [task['_id'] for task in self.storage.find_task({"_id": {"$regex": "restore_.+"}})]
+        self.assertListEqual(tasks, ['restore_10.2.2.2'])
 
     @patch("hm.log.logging")
     def test_restore_machine_iaas_fail(self, log):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -60,7 +60,7 @@ class ManagerTestCase(unittest.TestCase):
         self.Host.create.assert_called_with("my-host-manager", "x", config)
         self.LoadBalancer.create.assert_called_with("my-lb-manager", "x", config)
         lb.add_host.assert_called_with(host)
-        self.assertIsNone(self.storage.find_task("x"))
+        self.assertEquals(self.storage.find_task("x").count(), 0)
         nginx.Nginx.assert_called_once_with(config)
         nginx_manager = nginx.Nginx.return_value
         nginx_manager.wait_healthcheck.assert_called_once_with(host.dns_name, timeout=600)
@@ -80,7 +80,7 @@ class ManagerTestCase(unittest.TestCase):
         self.Host.create.assert_called_with("my-host-manager", "x", config)
         self.LoadBalancer.create.assert_called_with("my-lb-manager", "x", config)
         lb.add_host.assert_called_with(host)
-        self.assertIsNone(manager.storage.find_task("x"))
+        self.assertEquals(manager.storage.find_task("x").count(), 0)
         nginx.Nginx.assert_called_once_with(config)
         nginx_manager = nginx.Nginx.return_value
         nginx_manager.wait_healthcheck.assert_called_once_with(host.dns_name, timeout=600)
@@ -103,7 +103,7 @@ class ManagerTestCase(unittest.TestCase):
         self.Host.create.assert_called_with("my-host-manager", "x", config)
         self.LoadBalancer.create.assert_called_with("my-lb-manager", "x", config)
         lb.add_host.assert_called_with(host)
-        self.assertIsNone(manager.storage.find_task("x"))
+        self.assertEquals(manager.storage.find_task("x").count(), 0)
         nginx.Nginx.assert_called_once_with(config)
         nginx_manager = nginx.Nginx.return_value
         nginx_manager.wait_healthcheck.assert_called_once_with(host.dns_name, timeout=600)
@@ -149,7 +149,7 @@ class ManagerTestCase(unittest.TestCase):
         for h in lb.hosts:
             h.destroy.assert_called_once()
         lb.destroy.assert_called_once()
-        self.assertIsNone(self.storage.find_task("x"))
+        self.assertEquals(self.storage.find_task("x").count(), 0)
         self.assertIsNone(self.storage.find_instance_metadata("x"))
         manager.consul_manager.destroy_token.assert_called_with("abc-123")
         manager.consul_manager.destroy_instance.assert_called_with("x")
@@ -166,7 +166,7 @@ class ManagerTestCase(unittest.TestCase):
         for h in lb.hosts:
             h.destroy.assert_called_once()
         lb.destroy.assert_called_once()
-        self.assertIsNone(self.storage.find_task("x"))
+        self.assertEquals(self.storage.find_task("x").count(), 0)
         self.assertIsNone(self.storage.find_instance_metadata("x"))
         manager.consul_manager.destroy_token.assert_not_called()
 
@@ -194,7 +194,7 @@ class ManagerTestCase(unittest.TestCase):
                                                                "alternative_id": 0})
         manager.restore_machine_instance('foo', '10.1.1.1')
         task = self.storage.find_task("restore_10.1.1.1")
-        self.assertEqual(task['host'], "10.1.1.1")
+        self.assertEqual(task[0]['host'], "10.1.1.1")
 
     @mock.patch("rpaas.manager.LoadBalancer")
     def test_restore_machine_invalid_dns_name(self, LoadBalancer):
@@ -210,7 +210,7 @@ class ManagerTestCase(unittest.TestCase):
         self.storage.store_task("restore_10.1.1.1")
         manager.restore_machine_instance('foo', '10.1.1.1', True)
         task = self.storage.find_task("restore_10.1.1.1")
-        self.assertIsNone(task)
+        self.assertEquals(task.count(), 0)
 
     def teste_restore_machine_instance_cancel_invalid_task(self):
         manager = Manager(self.config)


### PR DESCRIPTION
Restore machine routes are used for third-party supervisor services (like consul). It spawns a thread which consumes restore_machine tasks. There is also a mechanism to delay next restore for all tasks which belongs to a instance on failure to restore to avoid unexpected behaviours. There is also a dry_mode for debug purposes.