### PR TITLE
lock: add service name to all locks by default

### DIFF
--- a/rpaas/healing.py
+++ b/rpaas/healing.py
@@ -14,10 +14,10 @@ class RestoreMachine(scheduler.JobScheduler):
     """
 
     def __init__(self, config=None, *args, **kwargs):
-        super(RestoreMachine, self).__init__(*args, **kwargs)
+        super(RestoreMachine, self).__init__(config, *args, **kwargs)
         self.config = config or dict(os.environ)
         self.interval = int(self.config.get("RESTORE_MACHINE_RUN_INTERVAL", 30))
-        self.last_run_key = self.config.get("RESTORE_MACHINE_LAST_RUN_KEY", "restore_machine:last_run")
+        self.last_run_key = self.get_last_run_key("RESTORE_MACHINE")
 
     def run(self):
         self.running = True
@@ -35,10 +35,10 @@ class CheckMachine(scheduler.JobScheduler):
     """
 
     def __init__(self, config=None, *args, **kwargs):
-        super(CheckMachine, self).__init__(*args, **kwargs)
+        super(CheckMachine, self).__init__(config, *args, **kwargs)
         self.config = config or dict(os.environ)
         self.interval = int(self.config.get("CHECK_MACHINE_RUN_INTERVAL", 30))
-        self.last_run_key = self.config.get("CHECK_MACHINE_LAST_RUN_KEY", "check_machine:last_run")
+        self.last_run_key = self.get_last_run_key("CHECK_MACHINE")
 
     def run(self):
         self.running = True

--- a/rpaas/scheduler.py
+++ b/rpaas/scheduler.py
@@ -25,9 +25,14 @@ class JobScheduler(threading.Thread):
         super(JobScheduler, self).__init__(*args, **kwargs)
         self.daemon = True
         self.config = config or dict(os.environ)
+        self.service_name = self.config.get("RPAAS_SERVICE_NAME", "rpaas")
         self.interval = int(self.config.get("JOB_SCHEDULER_RUN_INTERVAL", 30))
-        self.last_run_key = self.config.get("JOB_SCHEDULER_LAST_RUN_KEY", "job_scheduler:last_run")
+        self.last_run_key = self.get_last_run_key("JOB_SCHEDULER")
         self.conn = tasks.app.broker_connection().channel().client
+
+    def get_last_run_key(self, key):
+        last_run_key = "{}_LAST_RUN_KEY".format(key)
+        return self.config.get(last_run_key, "{}:{}:last_run".format(key.lower(), self.service_name))
 
     def try_lock(self):
         interval_delta = datetime.timedelta(seconds=self.interval)

--- a/rpaas/session_resumption.py
+++ b/rpaas/session_resumption.py
@@ -14,10 +14,10 @@ class SessionResumption(scheduler.JobScheduler):
     """
 
     def __init__(self, config=None, *args, **kwargs):
-        super(SessionResumption, self).__init__(*args, **kwargs)
+        super(SessionResumption, self).__init__(config, *args, **kwargs)
         self.config = config or dict(os.environ)
         self.interval = int(self.config.get("SESSION_RESUMPTION_RUN_INTERVAL", 300))
-        self.last_run_key = self.config.get("SESSION_RESUMPTION_LAST_RUN_KEY", "session_resumption:last_run")
+        self.last_run_key = self.get_last_run_key("SESSION_RESUMPTION")
 
     def run(self):
         self.running = True

--- a/rpaas/ssl_plugins/le_renewer.py
+++ b/rpaas/ssl_plugins/le_renewer.py
@@ -18,10 +18,10 @@ class LeRenewer(scheduler.JobScheduler):
     """
 
     def __init__(self, config=None, *args, **kwargs):
-        super(LeRenewer, self).__init__(*args, **kwargs)
+        super(LeRenewer, self).__init__(config, *args, **kwargs)
         self.config = config or dict(os.environ)
         self.interval = int(self.config.get("LE_RENEWER_RUN_INTERVAL", 86400))
-        self.last_run_key = self.config.get("LE_RENEWER_LAST_RUN_KEY", "le_renewer:last_run")
+        self.last_run_key = self.get_last_run_key("LE_RENEWER")
 
     def run(self):
         self.running = True

--- a/tests/test_healing.py
+++ b/tests/test_healing.py
@@ -138,7 +138,7 @@ class RestoreMachineTestCase(unittest.TestCase):
         self.assertEqual(nginx_manager.wait_healthcheck.call_args_list, [call('10.1.1.1', timeout=600)])
         log.reset_mock()
         nginx.reset_mock()
-        redis.StrictRedis().delete("restore_machine:last_run")
+        redis.StrictRedis().delete("restore_machine:test_rpaas_machine_restore:last_run")
         restorer = healing.RestoreMachine(self.config)
         restorer.start()
         time.sleep(1)
@@ -149,7 +149,7 @@ class RestoreMachineTestCase(unittest.TestCase):
         self.assertListEqual(['restore_10.2.2.2', 'restore_10.3.3.3', 'restore_10.4.4.4'], tasks)
         log.reset_mock()
         nginx.reset_mock()
-        redis.StrictRedis().delete("restore_machine:last_run")
+        redis.StrictRedis().delete("restore_machine:test_rpaas_machine_restore:last_run")
         FakeManager.fail_ids = []
         with freeze_time("2016-02-03 12:06:00"):
             restorer = healing.RestoreMachine(self.config)
@@ -320,7 +320,7 @@ class CheckMachineTestCase(unittest.TestCase):
         FakeManager.host_id = 0
         FakeManager.hosts = ['10.1.1.1', '10.2.2.2', '10.3.3.3']
 
-        redis.StrictRedis().delete("check_machine:last_run")
+        redis.StrictRedis().delete("check_machine:test_rpaas_check_machine:last_run")
 
     def tearDown(self):
         self.storage.db[self.storage.tasks_collection].remove()

--- a/tests/test_session_resumption.py
+++ b/tests/test_session_resumption.py
@@ -136,8 +136,8 @@ class SessionResumptionTestCase(unittest.TestCase):
         self.assertEqual(nginx_expected_calls, nginx_manager.add_session_ticket.call_args_list)
         cert_a, key_a = self.consul_manager.get_certificate("instance-a", "xxx")
         cert_b, key_b = self.consul_manager.get_certificate("instance-b", "bbb")
-        redis.StrictRedis().delete("session_resumption:last_run")
-        redis.StrictRedis().delete("session_resumption:instance:instance-a")
+        redis.StrictRedis().delete("session_resumption:test_rpaas_session_resumption:last_run")
+        redis.StrictRedis().delete("session_resumption:test_rpaas_session_resumption:instance:instance-a")
         nginx_manager.reset_mock()
         session = session_resumption.SessionResumption(self.config)
         session.start()
@@ -188,7 +188,7 @@ class SessionResumptionTestCase(unittest.TestCase):
         nginx_expected_calls = [call('10.1.1.1', 'ticket1', 30), call('10.2.2.2', 'ticket2', 30),
                                 call('10.2.2.3', 'ticket2', 30)]
         self.assertEqual(nginx_expected_calls, nginx_manager.add_session_ticket.call_args_list)
-        redis.StrictRedis().delete("session_resumption:last_run")
+        redis.StrictRedis().delete("session_resumption:test_rpaas_session_resumption:last_run")
         lb1_host2.unset_fail("dns_name")
         nginx_manager.reset_mock()
         session = session_resumption.SessionResumption(self.config)


### PR DESCRIPTION
When using a shared redis for multiple rpaas APIs, you should always redefine
your locks. This commit now guess lock names by service name by default.