### PR TITLE
nginx: use upstream to proxy_pass instead direct proxy

### DIFF
--- a/rpaas/consul_manager.py
+++ b/rpaas/consul_manager.py
@@ -161,10 +161,8 @@ class ConsulManager(object):
         upstream_name = self._host_from_destination(upstream_name)
         server = self._host_from_destination(server)
         servers = self._list_upstream(instance_name, upstream_name)
-        try:
+        if server in servers:
             servers.remove(server)
-        except KeyError:
-            pass
         if len(servers) < 1:
             self._remove_upstream(instance_name, upstream_name)
         else:

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -310,6 +310,8 @@ class Manager(object):
             if destination:
                 if p['destination'] == destination:
                     destination_count += 1
+        if destination_count == 0:
+            raise storage.InstanceNotFoundError()
         if destination_count < 2:
             self.consul_manager.remove_server_upstream(name, destination, destination)
         self.storage.delete_binding_path(name, path)

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -297,6 +297,21 @@ class Manager(object):
         lb = LoadBalancer.find(name)
         if lb is None:
             raise storage.InstanceNotFoundError()
+        routes = self.list_routes(name)
+        destination = None
+        destination_count = 0
+        if not routes:
+            raise storage.InstanceNotFoundError()
+        for p in routes['paths']:
+            if p['path'] == path:
+                destination = p['destination']
+                destination_count += 1
+                continue
+            if destination:
+                if p['destination'] == destination:
+                    destination_count += 1
+        if destination_count < 2:
+            self.consul_manager.remove_server_upstream(name, destination, destination)
         self.storage.delete_binding_path(name, path)
         self.consul_manager.remove_location(name, path)
 

--- a/rpaas/nginx.py
+++ b/rpaas/nginx.py
@@ -39,10 +39,11 @@ class ConfigManager(object):
     def __init__(self, conf=None):
         self.location_template = self._load_location_template(conf)
 
-    def generate_host_config(self, path, destination):
+    def generate_host_config(self, path, destination, upstream):
         return self.location_template.format(
             path=path.rstrip('/') + '/',
             host=destination,
+            upstream=upstream
         )
 
     def _load_location_template(self, conf):
@@ -63,7 +64,9 @@ location {path} {{
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $host;
-    proxy_pass http://{host}:80/;
+    proxy_set_header Connection "";
+    proxy_http_version 1.1;
+    proxy_pass http://{upstream};
     proxy_redirect ~^http://{host}(:\d+)?/(.*)$ {path}$2;
 }}
 """

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -270,3 +270,28 @@ class ConsulManagerTestCase(unittest.TestCase):
         empty_block_value = """-- Begin custom RpaaS some_module lua module --
 \n-- End custom RpaaS some_module lua module --"""
         self.assertEqual(item[1]['Value'], empty_block_value)
+
+    def test_upstream_add_to_empty_upstrem(self):
+        self.manager.add_server_upstream("myrpaas", "upstream1", "server1")
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/upstream1")
+        self.assertEqual("server1", item[1]["Value"])
+
+    def test_upstream_add_existing_server_to_upstream(self):
+        self.manager.add_server_upstream("myrpaas", "upstream1", "server1")
+        self.manager.add_server_upstream("myrpaas", "upstream1", "server1")
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/upstream1")
+        self.assertEqual("server1", item[1]["Value"])
+
+    def test_upstream_remove_server_from_upstream(self):
+        self.manager.add_server_upstream("myrpaas", "upstream1", "server1")
+        self.manager.add_server_upstream("myrpaas", "upstream1", "server2")
+        self.manager.add_server_upstream("myrpaas", "upstream1", "server3")
+        self.manager.remove_server_upstream("myrpaas", "upstream1", "server2")
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/upstream1")
+        self.assertEqual("server1,server3", item[1]["Value"])
+
+    def test_upstream_remove_server_not_found_on_upstream(self):
+        self.manager.add_server_upstream("myrpaas", "upstream1", "server1")
+        self.manager.remove_server_upstream("myrpaas", "upstream1", "server2")
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/upstream1")
+        self.assertEqual("server1", item[1]["Value"])

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -103,7 +103,9 @@ class ConsulManagerTestCase(unittest.TestCase):
         self.manager.write_location("myrpaas", "/", destination="http://myapp.tsuru.io")
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/ROOT")
         expected = self.manager.config_manager.generate_host_config(path="/",
-                                                                    destination="http://myapp.tsuru.io")
+                                                                    destination="http://myapp.tsuru.io",
+                                                                    upstream="myapp.tsuru.io"
+                                                                    )
         self.assertEqual(expected, item[1]["Value"])
 
     def test_write_location_non_root(self):
@@ -111,7 +113,9 @@ class ConsulManagerTestCase(unittest.TestCase):
                                     destination="http://myapp.tsuru.io")
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/___admin___app_sites___")
         expected = self.manager.config_manager.generate_host_config(path="/admin/app_sites/",
-                                                                    destination="http://myapp.tsuru.io")
+                                                                    destination="http://myapp.tsuru.io",
+                                                                    upstream="myapp.tsuru.io"
+                                                                    )
         self.assertEqual(expected, item[1]["Value"])
 
     def test_write_location_content(self):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -921,6 +921,30 @@ content = location /x {
             "app_host": "app.host.com",
             "paths": [{"path": "/", "destination": "app.host.com"}]
         })
+        manager.consul_manager.remove_server_upstream.assert_called_once_with("inst", "dune.com", "dune.com")
+        manager.consul_manager.remove_location.assert_called_with("inst", "/arrakis")
+
+    @mock.patch("rpaas.manager.LoadBalancer")
+    def test_delete_route_only_remove_upstream_on_last_reference(self, LoadBalancer):
+        self.storage.store_binding("inst", "app.host.com")
+        self.storage.replace_binding_path("inst", "/arrakis", "dune.com")
+        self.storage.replace_binding_path("inst", "/atreides", "dune.com")
+        lb = LoadBalancer.find.return_value
+        lb.hosts = [mock.Mock(), mock.Mock()]
+
+        manager = Manager(self.config)
+        manager.consul_manager = mock.Mock()
+        manager.delete_route("inst", "/arrakis")
+
+        LoadBalancer.find.assert_called_with("inst")
+        binding_data = self.storage.find_binding("inst")
+        self.assertDictEqual(binding_data, {
+            "_id": "inst",
+            "app_host": "app.host.com",
+            "paths": [{"path": "/", "destination": "app.host.com"},
+                      {"path": "/atreides", "destination": "dune.com", "content": None}]
+        })
+        manager.consul_manager.remove_server_upstream.assert_not_called()
         manager.consul_manager.remove_location.assert_called_with("inst", "/arrakis")
 
     def test_delete_route_error_task_running(self):

--- a/tests/test_nginx.py
+++ b/tests/test_nginx.py
@@ -26,7 +26,9 @@ location {path} {{
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $host;
-    proxy_pass http://{host}:80/;
+    proxy_set_header Connection "";
+    proxy_http_version 1.1;
+    proxy_pass http://{upstream};
     proxy_redirect ~^http://{host}(:\d+)?/(.*)$ {path}$2;
 }}
 """)


### PR DESCRIPTION
Add methods to handle upstream routes and change default nginx template to use upstream with keepalive instead  direct proxy to destination.