### PR TITLE
router_api: bind to / should points to an empty upstream

### DIFF
--- a/rpaas/consul_manager.py
+++ b/rpaas/consul_manager.py
@@ -154,9 +154,9 @@ class ConsulManager(object):
         self.write_lua(instance_name, lua_module_name, lua_module_type, None)
 
     def add_server_upstream(self, instance_name, upstream_name, server):
-        servers = self.list_upstream(instance_name, upstream_name)
         if not server:
             return
+        servers = self.list_upstream(instance_name, upstream_name)
         if isinstance(server, list):
             for idx, _ in enumerate(server):
                 server[idx] = ":".join(map(str, filter(None, self._host_from_destination(server[idx]))))

--- a/rpaas/consul_manager.py
+++ b/rpaas/consul_manager.py
@@ -78,13 +78,16 @@ class ConsulManager(object):
                 node_status_list[node_server_name] = node['Value']
         return node_status_list
 
-    def write_location(self, instance_name, path, destination=None, content=None):
+    def write_location(self, instance_name, path, destination=None, content=None, empty_uptream=False):
         if content:
             content = content.strip()
         else:
             upstream = self._host_from_destination(destination)
+            upstream_server = upstream
             content = self.config_manager.generate_host_config(path, destination, upstream)
-            self.add_server_upstream(instance_name, upstream, upstream)
+            if empty_uptream:
+                upstream_server = None
+            self.add_server_upstream(instance_name, upstream, upstream_server)
         self.client.kv.put(self._location_key(instance_name, path), content)
 
     def remove_location(self, instance_name, path):
@@ -152,6 +155,8 @@ class ConsulManager(object):
 
     def add_server_upstream(self, instance_name, upstream_name, server):
         servers = self.list_upstream(instance_name, upstream_name)
+        if not server:
+            return
         if isinstance(server, list):
             servers |= set(server)
         else:

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -158,7 +158,7 @@ class Manager(object):
         finally:
             self.task_manager.remove(name)
 
-    def bind(self, name, app_host):
+    def bind(self, name, app_host, router_mode=False):
         self.task_manager.ensure_ready(name)
         lb = LoadBalancer.find(name)
         if lb is None:
@@ -171,7 +171,10 @@ class Manager(object):
                 return
             if bound_host is not None:
                 raise BindError("This service can only be bound to one application.")
-        self.consul_manager.write_location(name, "/", destination=app_host)
+        empty_upstream = False
+        if router_mode:
+            empty_upstream = True
+        self.consul_manager.write_location(name, "/", destination=app_host, empty_upstream=empty_upstream)
         self.storage.store_binding(name, app_host)
 
     def unbind(self, name, app_host):

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -171,10 +171,7 @@ class Manager(object):
                 return
             if bound_host is not None:
                 raise BindError("This service can only be bound to one application.")
-        empty_upstream = False
-        if router_mode:
-            empty_upstream = True
-        self.consul_manager.write_location(name, "/", destination=app_host, empty_upstream=empty_upstream)
+        self.consul_manager.write_location(name, "/", destination=app_host, empty_upstream=router_mode)
         self.storage.store_binding(name, app_host)
 
     def unbind(self, name, app_host):

--- a/rpaas/router_api.py
+++ b/rpaas/router_api.py
@@ -116,7 +116,7 @@ def add_routes(name):
         return "Addresses cannot be empty", 400
     m = get_manager()
     try:
-        m.bind(name, name)
+        m.bind(name, name, router_mode=True)
         m.add_upstream(name, name, addresses)
     except tasks.NotReadyError as e:
         return "Backend not ready: {}".format(e), 412

--- a/tests/managers.py
+++ b/tests/managers.py
@@ -41,7 +41,7 @@ class FakeManager(object):
         self.instances.append(instance)
         return instance
 
-    def bind(self, name, app_host):
+    def bind(self, name, app_host, router_mode=False):
         index, instance = self.find_instance(name)
         if index < 0:
             raise storage.InstanceNotFoundError()

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -107,6 +107,19 @@ class ConsulManagerTestCase(unittest.TestCase):
                                                                     upstream="myapp.tsuru.io"
                                                                     )
         self.assertEqual(expected, item[1]["Value"])
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/myapp.tsuru.io")
+        self.assertEqual("myapp.tsuru.io", item[1]["Value"])
+
+    def test_write_location_root_router_mode(self):
+        self.manager.write_location("router-myrpaas", "/", destination="router-myrpaas", empty_uptream=True)
+        item = self.consul.kv.get("test-suite-rpaas/router-myrpaas/locations/ROOT")
+        expected = self.manager.config_manager.generate_host_config(path="/",
+                                                                    destination="router-myrpaas",
+                                                                    upstream="router-myrpaas"
+                                                                    )
+        self.assertEqual(expected, item[1]["Value"])
+        item = self.consul.kv.get("test-suite-rpaas/router-myrpaas/upstream/router-myrpaas")
+        self.assertEqual(None, item[1])
 
     def test_write_location_non_root(self):
         self.manager.write_location("myrpaas", "/admin/app_sites/",

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -305,6 +305,13 @@ class ConsulManagerTestCase(unittest.TestCase):
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/upstream1")
         self.assertEqual("server1,server2,server3", item[1]["Value"])
 
+    def test_upstream_add_bulk_urls_to_existing_upstream(self):
+        self.manager.add_server_upstream("myrpaas", "upstream1", "http://server1:123")
+        self.manager.add_server_upstream("myrpaas", "upstream1", ["http://server1:123", "http://server2:456",
+                                                                  "http://server3:789"])
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/upstream1")
+        self.assertEqual("server3:789,server2:456,server1:123", item[1]["Value"])
+
     def test_upstream_remove_server_from_upstream(self):
         self.manager.add_server_upstream("myrpaas", "upstream1", "server1")
         self.manager.add_server_upstream("myrpaas", "upstream1", "server2")
@@ -324,3 +331,11 @@ class ConsulManagerTestCase(unittest.TestCase):
         self.manager.remove_server_upstream("myrpaas", "upstream1", ["server2", "server3", "server4"])
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/upstream1")
         self.assertEqual("server1", item[1]["Value"])
+
+    def test_upstream_remove_bulk_urls_on_existing_upstream(self):
+        self.manager.add_server_upstream("myrpaas", "upstream1", ["http://server1:123", "http://server2:456",
+                                                                  "http://server3:789"])
+        self.manager.remove_server_upstream("myrpaas", "upstream1", ["http://server2:456", "http://server3:789",
+                                                                     "http://server4:333"])
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/upstream1")
+        self.assertEqual("server1:123", item[1]["Value"])

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -673,7 +673,8 @@ content = location /x {
             "paths": [{"path": "/", "destination": "apphost.com"}]
         })
         LoadBalancer.find.assert_called_with("x")
-        manager.consul_manager.write_location.assert_called_with("x", "/", destination="apphost.com")
+        manager.consul_manager.write_location.assert_called_with("x", "/", destination="apphost.com",
+                                                                 empty_upstream=False)
 
     def test_bind_instance_error_task_running(self):
         self.storage.store_task("x")
@@ -695,7 +696,8 @@ content = location /x {
             "paths": [{"path": "/", "destination": "apphost.com"}]
         })
         LoadBalancer.find.assert_called_with("x")
-        manager.consul_manager.write_location.assert_called_with("x", "/", destination="apphost.com")
+        manager.consul_manager.write_location.assert_called_with("x", "/", destination="apphost.com",
+                                                                 empty_upstream=False)
         manager.consul_manager.reset_mock()
         manager.bind("x", "apphost.com")
         self.assertEqual(0, len(manager.consul_manager.mock_calls))
@@ -725,7 +727,7 @@ content = location /x {
         LoadBalancer.find.assert_called_with("x")
         manager.consul_manager.write_location.assert_any_call("x", "/somewhere", destination="my.other.host",
                                                               content=None)
-        manager.consul_manager.write_location.assert_any_call("x", "/", destination="apphost.com")
+        manager.consul_manager.write_location.assert_any_call("x", "/", destination="apphost.com", empty_upstream=False)
 
     @mock.patch("rpaas.manager.LoadBalancer")
     def test_unbind_instance(self, LoadBalancer):
@@ -783,7 +785,8 @@ content = location /x {
         })
         LoadBalancer.find.assert_called_with("inst")
         manager.consul_manager.remove_location.assert_called_with("inst", "/")
-        manager.consul_manager.write_location.assert_called_with("inst", "/", destination="app2.host.com")
+        manager.consul_manager.write_location.assert_called_with("inst", "/", destination="app2.host.com",
+                                                                 empty_upstream=False)
 
     @mock.patch("rpaas.manager.LoadBalancer")
     def test_update_certificate(self, LoadBalancer):


### PR DESCRIPTION
Change bind to support empty upstream instead default to destination hostname -
which is invalid when using it in router mode.