### PR TITLE
manager/unbind: return 404 for / on unbind

### DIFF
--- a/rpaas/api.py
+++ b/rpaas/api.py
@@ -136,7 +136,7 @@ def unbind(name):
     if not app_host:
         return "app-host is required", 400
     try:
-        get_manager().unbind(name, app_host)
+        get_manager().unbind(name)
     except tasks.NotReadyError as e:
         return "Instance not ready: {}".format(e), 412
     except storage.InstanceNotFoundError:

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -183,12 +183,7 @@ class Manager(object):
         if not binding_data:
             return
         self.storage.remove_root_binding(name)
-        content_instance_not_bound = '''
-        location / {
-            return 404 "Instance not bound";
-        }
-        '''
-        self.consul_manager.write_location(name, "/", content=content_instance_not_bound)
+        self.consul_manager.write_location(name, "/", content=nginx.NGINX_LOCATION_INSTANCE_NOT_BOUND)
 
     def info(self, name):
         addr = self._get_address(name)

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -174,7 +174,7 @@ class Manager(object):
         self.consul_manager.write_location(name, "/", destination=app_host, empty_upstream=router_mode)
         self.storage.store_binding(name, app_host)
 
-    def unbind(self, name, app_host):
+    def unbind(self, name):
         self.task_manager.ensure_ready(name)
         lb = LoadBalancer.find(name)
         if lb is None:
@@ -183,7 +183,12 @@ class Manager(object):
         if not binding_data:
             return
         self.storage.remove_root_binding(name)
-        self.consul_manager.remove_location(name, "/")
+        content_instance_not_bound = '''
+        location / {
+            return 404 "Instance not bound";
+        }
+        '''
+        self.consul_manager.write_location(name, "/", content=content_instance_not_bound)
 
     def info(self, name):
         addr = self._get_address(name)

--- a/rpaas/router_api.py
+++ b/rpaas/router_api.py
@@ -138,6 +138,9 @@ def delete_routes(name):
     m = get_manager()
     try:
         m.remove_upstream(name, name, addresses)
+        routes = m.list_upstreams(name, name)
+        if len(routes) < 1:
+            m.unbind(name)
     except tasks.NotReadyError as e:
         return "Backend not ready: {}".format(e), 412
     except storage.InstanceNotFoundError:

--- a/tests/managers.py
+++ b/tests/managers.py
@@ -14,18 +14,12 @@ class FakeInstance(object):
         self.state = state
         self.units = 1
         self.plan = plan
-        self.bound = []
+        self.bound = False
         self.routes = {}
         self.blocks = {}
         self.lua_modules = {}
         self.node_status = {}
         self.upstreams = defaultdict(set)
-
-    def bind(self, app_host):
-        self.bound.append(app_host)
-
-    def unbind(self, app_host):
-        self.bound.remove(app_host)
 
 
 class FakeManager(object):
@@ -45,13 +39,19 @@ class FakeManager(object):
         index, instance = self.find_instance(name)
         if index < 0:
             raise storage.InstanceNotFoundError()
-        instance.bind(app_host)
+        instance.bound = True
 
-    def unbind(self, name, app_host):
+    def unbind(self, name):
         index, instance = self.find_instance(name)
         if index < 0:
             raise storage.InstanceNotFoundError()
-        instance.unbind(app_host)
+        instance.bound = False
+
+    def check_bound(self, name):
+        index, instance = self.find_instance(name)
+        if index < 0:
+            raise storage.InstanceNotFoundError()
+        return instance.bound
 
     def remove_instance(self, name):
         index, _ = self.find_instance(name)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -209,8 +209,7 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(201, resp.status_code)
         self.assertEqual("null", resp.data)
         self.assertEqual("application/json", resp.mimetype)
-        bind = self.manager.instances[0].bound[0]
-        self.assertEqual("someapp.cloud.tsuru.io", bind)
+        self.assertTrue(self.manager.instances[0].bound)
 
     def test_bind_without_app_host(self):
         resp = self.api.post("/resources/someapp/bind-app",
@@ -242,7 +241,7 @@ class APITestCase(unittest.TestCase):
                                         'application/x-www-form-urlencoded'})
         self.assertEqual(200, resp.status_code)
         self.assertEqual("", resp.data)
-        self.assertEqual([], self.manager.instances[0].bound)
+        self.assertFalse(self.manager.instances[0].bound)
 
     def test_unbind_instance_not_found(self):
         resp = self.api.delete("/resources/someapp/bind-app", data={"app-host":

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -10,7 +10,7 @@ import mock
 
 import rpaas.manager
 from rpaas.manager import Manager, ScaleError, QuotaExceededError
-from rpaas import tasks, storage
+from rpaas import tasks, storage, nginx
 
 tasks.app.conf.CELERY_ALWAYS_EAGER = True
 
@@ -743,11 +743,7 @@ content = location /x {
             "paths": []
         })
         LoadBalancer.find.assert_called_with("inst")
-        content_instance_not_bound = '''
-        location / {
-            return 404 "Instance not bound";
-        }
-        '''
+        content_instance_not_bound = nginx.NGINX_LOCATION_INSTANCE_NOT_BOUND
         manager.consul_manager.write_location.assert_called_with("inst", "/", content=content_instance_not_bound)
 
     @mock.patch("rpaas.manager.LoadBalancer")
@@ -767,11 +763,7 @@ content = location /x {
             ]
         })
         LoadBalancer.find.assert_called_with("inst")
-        content_instance_not_bound = '''
-        location / {
-            return 404 "Instance not bound";
-        }
-        '''
+        content_instance_not_bound = nginx.NGINX_LOCATION_INSTANCE_NOT_BOUND
         manager.consul_manager.write_location.assert_called_with("inst", "/", content=content_instance_not_bound)
 
     @mock.patch("rpaas.manager.LoadBalancer")
@@ -794,11 +786,7 @@ content = location /x {
             ]
         })
         LoadBalancer.find.assert_called_with("inst")
-        content_instance_not_bound = '''
-        location / {
-            return 404 "Instance not bound";
-        }
-        '''
+        content_instance_not_bound = nginx.NGINX_LOCATION_INSTANCE_NOT_BOUND
         expected_calls = [mock.call("inst", "/", content=content_instance_not_bound),
                           mock.call("inst", "/", destination="app2.host.com", empty_upstream=False)]
         manager.consul_manager.write_location.assert_has_calls(expected_calls)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -736,14 +736,19 @@ content = location /x {
         lb.hosts = [mock.Mock(), mock.Mock()]
         manager = Manager(self.config)
         manager.consul_manager = mock.Mock()
-        manager.unbind("inst", "app.host.com")
+        manager.unbind("inst")
         binding_data = self.storage.find_binding("inst")
         self.assertDictEqual(binding_data, {
             "_id": "inst",
             "paths": []
         })
         LoadBalancer.find.assert_called_with("inst")
-        manager.consul_manager.remove_location.assert_called_with("inst", "/")
+        content_instance_not_bound = '''
+        location / {
+            return 404 "Instance not bound";
+        }
+        '''
+        manager.consul_manager.write_location.assert_called_with("inst", "/", content=content_instance_not_bound)
 
     @mock.patch("rpaas.manager.LoadBalancer")
     def test_unbind_instance_with_extra_path(self, LoadBalancer):
@@ -753,7 +758,7 @@ content = location /x {
         lb.hosts = [mock.Mock(), mock.Mock()]
         manager = Manager(self.config)
         manager.consul_manager = mock.Mock()
-        manager.unbind("inst", "app.host.com")
+        manager.unbind("inst")
         binding_data = self.storage.find_binding("inst")
         self.assertDictEqual(binding_data, {
             "_id": "inst",
@@ -762,7 +767,12 @@ content = location /x {
             ]
         })
         LoadBalancer.find.assert_called_with("inst")
-        manager.consul_manager.remove_location.assert_called_with("inst", "/")
+        content_instance_not_bound = '''
+        location / {
+            return 404 "Instance not bound";
+        }
+        '''
+        manager.consul_manager.write_location.assert_called_with("inst", "/", content=content_instance_not_bound)
 
     @mock.patch("rpaas.manager.LoadBalancer")
     def test_unbind_and_bind_instance_with_extra_path(self, LoadBalancer):
@@ -772,7 +782,7 @@ content = location /x {
         lb.hosts = [mock.Mock(), mock.Mock()]
         manager = Manager(self.config)
         manager.consul_manager = mock.Mock()
-        manager.unbind("inst", "app.host.com")
+        manager.unbind("inst")
         manager.bind("inst", "app2.host.com")
         binding_data = self.storage.find_binding("inst")
         self.assertDictEqual(binding_data, {
@@ -784,9 +794,14 @@ content = location /x {
             ]
         })
         LoadBalancer.find.assert_called_with("inst")
-        manager.consul_manager.remove_location.assert_called_with("inst", "/")
-        manager.consul_manager.write_location.assert_called_with("inst", "/", destination="app2.host.com",
-                                                                 empty_upstream=False)
+        content_instance_not_bound = '''
+        location / {
+            return 404 "Instance not bound";
+        }
+        '''
+        expected_calls = [mock.call("inst", "/", content=content_instance_not_bound),
+                          mock.call("inst", "/", destination="app2.host.com", empty_upstream=False)]
+        manager.consul_manager.write_location.assert_has_calls(expected_calls)
 
     @mock.patch("rpaas.manager.LoadBalancer")
     def test_update_certificate(self, LoadBalancer):

--- a/tests/test_router_api.py
+++ b/tests/test_router_api.py
@@ -185,3 +185,21 @@ class RouterAPITestCase(unittest.TestCase):
         routes = self.manager.list_upstreams(
             "router-someapp", "router-someapp")
         self.assertEqual(["10.0.0.1:123"], sorted(list(routes)))
+
+    def test_remove_all_routes(self):
+        self.manager.new_instance("router-someapp")
+        self.manager.add_upstream(
+            "router-someapp", "router-someapp", "10.0.0.1:123")
+        self.manager.add_upstream(
+            "router-someapp", "router-someapp", "10.0.0.2:123")
+        self.manager.bind("router-someapp", "router-someapp")
+        self.assertTrue(self.manager.check_bound("router-someapp"))
+        resp = self.api.post("/router/backend/someapp/routes/remove", data=json.dumps({'addresses': ["10.0.0.2:123",
+                                                                                                     "10.0.0.1:123"]}),
+                             content_type="application/json")
+        self.assertEqual(200, resp.status_code)
+        routes = self.manager.list_upstreams(
+            "router-someapp", "router-someapp")
+        self.assertEqual(set([]), routes)
+        routes = self.manager.list_routes("router-someapp")
+        self.assertFalse(self.manager.check_bound("router-someapp"))


### PR DESCRIPTION
When removing all upstream members, today rpaas leave a wrong location / pointing
to an invalid upstream. Now when unbind occurs manager will write a location /
returning 404 "Instance not bound"