### PR TITLE
nginx: add location template for router mode

### DIFF
--- a/rpaas/consul_manager.py
+++ b/rpaas/consul_manager.py
@@ -78,14 +78,14 @@ class ConsulManager(object):
                 node_status_list[node_server_name] = node['Value']
         return node_status_list
 
-    def write_location(self, instance_name, path, destination=None, content=None, empty_upstream=False):
+    def write_location(self, instance_name, path, destination=None, content=None, router_mode=False):
         if content:
             content = content.strip()
         else:
             upstream, _ = self._host_from_destination(destination)
             upstream_server = upstream
-            content = self.config_manager.generate_host_config(path, destination, upstream)
-            if empty_upstream:
+            content = self.config_manager.generate_host_config(path, destination, upstream, router_mode)
+            if router_mode:
                 upstream_server = None
             self.add_server_upstream(instance_name, upstream, upstream_server)
         self.client.kv.put(self._location_key(instance_name, path), content)

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -171,7 +171,7 @@ class Manager(object):
                 return
             if bound_host is not None:
                 raise BindError("This service can only be bound to one application.")
-        self.consul_manager.write_location(name, "/", destination=app_host, empty_upstream=router_mode)
+        self.consul_manager.write_location(name, "/", destination=app_host, router_mode=router_mode)
         self.storage.store_binding(name, app_host)
 
     def unbind(self, name):

--- a/rpaas/nginx.py
+++ b/rpaas/nginx.py
@@ -16,7 +16,7 @@ location / {
 }
 '''
 
-NGIX_LOCATION_TEMPLATE_DEFAULT = '''
+NGINX_LOCATION_TEMPLATE_DEFAULT = '''
 location {path} {{
     proxy_set_header Host {host};
     proxy_set_header X-Real-IP $remote_addr;
@@ -30,7 +30,7 @@ location {path} {{
 }}
 '''
 
-NGIX_LOCATION_TEMPLATE_ROUTER = '''
+NGINX_LOCATION_TEMPLATE_ROUTER = '''
 location {path} {{
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -97,9 +97,9 @@ class ConfigManager(object):
                 raise NginxError("Error trying to load location template: {} - {}".
                                  format(rsp.status_code, rsp.text))
             return rsp.text
-        if mode == "default":
-            return NGIX_LOCATION_TEMPLATE_DEFAULT
-        return NGIX_LOCATION_TEMPLATE_ROUTER
+        if mode == "DEFAULT":
+            return NGINX_LOCATION_TEMPLATE_DEFAULT
+        return NGINX_LOCATION_TEMPLATE_ROUTER
 
 
 class Nginx(object):

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -8,7 +8,7 @@ import mock
 
 import consul
 
-from rpaas import consul_manager
+from rpaas import consul_manager, nginx
 
 
 class ConsulManagerTestCase(unittest.TestCase):
@@ -102,11 +102,9 @@ class ConsulManagerTestCase(unittest.TestCase):
     def test_write_location_root(self):
         self.manager.write_location("myrpaas", "/", destination="http://myapp.tsuru.io")
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/ROOT")
-        expected = self.manager.config_manager.generate_host_config(path="/",
-                                                                    destination="http://myapp.tsuru.io",
-                                                                    upstream="myapp.tsuru.io",
-                                                                    router_mode=False
-                                                                    )
+        expected = nginx.NGINX_LOCATION_TEMPLATE_DEFAULT.format(path="/",
+                                                                host="http://myapp.tsuru.io",
+                                                                upstream="myapp.tsuru.io")
         self.assertEqual(expected, item[1]["Value"])
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/myapp.tsuru.io")
         self.assertEqual("myapp.tsuru.io", item[1]["Value"])
@@ -114,11 +112,9 @@ class ConsulManagerTestCase(unittest.TestCase):
     def test_write_location_root_router_mode(self):
         self.manager.write_location("router-myrpaas", "/", destination="router-myrpaas", router_mode=True)
         item = self.consul.kv.get("test-suite-rpaas/router-myrpaas/locations/ROOT")
-        expected = self.manager.config_manager.generate_host_config(path="/",
-                                                                    destination="router-myrpaas",
-                                                                    upstream="router-myrpaas",
-                                                                    router_mode=True
-                                                                    )
+        expected = nginx.NGINX_LOCATION_TEMPLATE_ROUTER.format(path="/",
+                                                               host="router-myrpaas",
+                                                               upstream="router-myrpaas")
         self.assertEqual(expected, item[1]["Value"])
         item = self.consul.kv.get("test-suite-rpaas/router-myrpaas/upstream/router-myrpaas")
         self.assertEqual(None, item[1])
@@ -127,11 +123,9 @@ class ConsulManagerTestCase(unittest.TestCase):
         self.manager.write_location("myrpaas", "/admin/app_sites/",
                                     destination="http://myapp.tsuru.io")
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/___admin___app_sites___")
-        expected = self.manager.config_manager.generate_host_config(path="/admin/app_sites/",
-                                                                    destination="http://myapp.tsuru.io",
-                                                                    upstream="myapp.tsuru.io",
-                                                                    router_mode=False
-                                                                    )
+        expected = nginx.NGINX_LOCATION_TEMPLATE_DEFAULT.format(path="/admin/app_sites/",
+                                                                host="http://myapp.tsuru.io",
+                                                                upstream="myapp.tsuru.io")
         self.assertEqual(expected, item[1]["Value"])
 
     def test_write_location_content(self):

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -104,18 +104,20 @@ class ConsulManagerTestCase(unittest.TestCase):
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/ROOT")
         expected = self.manager.config_manager.generate_host_config(path="/",
                                                                     destination="http://myapp.tsuru.io",
-                                                                    upstream="myapp.tsuru.io"
+                                                                    upstream="myapp.tsuru.io",
+                                                                    router_mode=False
                                                                     )
         self.assertEqual(expected, item[1]["Value"])
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/myapp.tsuru.io")
         self.assertEqual("myapp.tsuru.io", item[1]["Value"])
 
     def test_write_location_root_router_mode(self):
-        self.manager.write_location("router-myrpaas", "/", destination="router-myrpaas", empty_upstream=True)
+        self.manager.write_location("router-myrpaas", "/", destination="router-myrpaas", router_mode=True)
         item = self.consul.kv.get("test-suite-rpaas/router-myrpaas/locations/ROOT")
         expected = self.manager.config_manager.generate_host_config(path="/",
                                                                     destination="router-myrpaas",
-                                                                    upstream="router-myrpaas"
+                                                                    upstream="router-myrpaas",
+                                                                    router_mode=True
                                                                     )
         self.assertEqual(expected, item[1]["Value"])
         item = self.consul.kv.get("test-suite-rpaas/router-myrpaas/upstream/router-myrpaas")
@@ -127,7 +129,8 @@ class ConsulManagerTestCase(unittest.TestCase):
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/___admin___app_sites___")
         expected = self.manager.config_manager.generate_host_config(path="/admin/app_sites/",
                                                                     destination="http://myapp.tsuru.io",
-                                                                    upstream="myapp.tsuru.io"
+                                                                    upstream="myapp.tsuru.io",
+                                                                    router_mode=False
                                                                     )
         self.assertEqual(expected, item[1]["Value"])
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -674,7 +674,7 @@ content = location /x {
         })
         LoadBalancer.find.assert_called_with("x")
         manager.consul_manager.write_location.assert_called_with("x", "/", destination="apphost.com",
-                                                                 empty_upstream=False)
+                                                                 router_mode=False)
 
     def test_bind_instance_error_task_running(self):
         self.storage.store_task("x")
@@ -697,7 +697,7 @@ content = location /x {
         })
         LoadBalancer.find.assert_called_with("x")
         manager.consul_manager.write_location.assert_called_with("x", "/", destination="apphost.com",
-                                                                 empty_upstream=False)
+                                                                 router_mode=False)
         manager.consul_manager.reset_mock()
         manager.bind("x", "apphost.com")
         self.assertEqual(0, len(manager.consul_manager.mock_calls))
@@ -727,7 +727,7 @@ content = location /x {
         LoadBalancer.find.assert_called_with("x")
         manager.consul_manager.write_location.assert_any_call("x", "/somewhere", destination="my.other.host",
                                                               content=None)
-        manager.consul_manager.write_location.assert_any_call("x", "/", destination="apphost.com", empty_upstream=False)
+        manager.consul_manager.write_location.assert_any_call("x", "/", destination="apphost.com", router_mode=False)
 
     @mock.patch("rpaas.manager.LoadBalancer")
     def test_unbind_instance(self, LoadBalancer):
@@ -788,7 +788,7 @@ content = location /x {
         LoadBalancer.find.assert_called_with("inst")
         content_instance_not_bound = nginx.NGINX_LOCATION_INSTANCE_NOT_BOUND
         expected_calls = [mock.call("inst", "/", content=content_instance_not_bound),
-                          mock.call("inst", "/", destination="app2.host.com", empty_upstream=False)]
+                          mock.call("inst", "/", destination="app2.host.com", router_mode=False)]
         manager.consul_manager.write_location.assert_has_calls(expected_calls)
 
     @mock.patch("rpaas.manager.LoadBalancer")


### PR DESCRIPTION
Rpaas working as router mode doesn't need to replace host header on nginx
proxy_pass conf. This PR add an additional template for location when in router mode.