### PR TITLE
manager: add default upstream name for bind as rpaas_default_upstream

### DIFF
--- a/rpaas/consul_manager.py
+++ b/rpaas/consul_manager.py
@@ -78,12 +78,14 @@ class ConsulManager(object):
                 node_status_list[node_server_name] = node['Value']
         return node_status_list
 
-    def write_location(self, instance_name, path, destination=None, content=None, router_mode=False):
+    def write_location(self, instance_name, path, destination=None, content=None, router_mode=False, bind_mode=False):
         if content:
             content = content.strip()
         else:
             upstream, _ = self._host_from_destination(destination)
             upstream_server = upstream
+            if bind_mode:
+                upstream = "rpaas_default_upstream"
             content = self.config_manager.generate_host_config(path, destination, upstream, router_mode)
             if router_mode:
                 upstream_server = None

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -171,7 +171,10 @@ class Manager(object):
                 return
             if bound_host is not None:
                 raise BindError("This service can only be bound to one application.")
-        self.consul_manager.write_location(name, "/", destination=app_host, router_mode=router_mode)
+        if not router_mode:
+            bind_mode = True
+        self.consul_manager.write_location(name, "/", destination=app_host, router_mode=router_mode,
+                                           bind_mode=bind_mode)
         self.storage.store_binding(name, app_host)
 
     def unbind(self, name):
@@ -185,7 +188,7 @@ class Manager(object):
         bound_host = binding_data.get("app_host")
         self.storage.remove_root_binding(name)
         self.consul_manager.write_location(name, "/", content=nginx.NGINX_LOCATION_INSTANCE_NOT_BOUND)
-        self.consul_manager.remove_server_upstream(name, bound_host, bound_host)
+        self.consul_manager.remove_server_upstream(name, "rpaas_default_upstream", bound_host)
 
     def info(self, name):
         addr = self._get_address(name)

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -171,8 +171,7 @@ class Manager(object):
                 return
             if bound_host is not None:
                 raise BindError("This service can only be bound to one application.")
-        if not router_mode:
-            bind_mode = True
+        bind_mode = not router_mode
         self.consul_manager.write_location(name, "/", destination=app_host, router_mode=router_mode,
                                            bind_mode=bind_mode)
         self.storage.store_binding(name, app_host)

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -109,6 +109,16 @@ class ConsulManagerTestCase(unittest.TestCase):
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/myapp.tsuru.io")
         self.assertEqual("myapp.tsuru.io", item[1]["Value"])
 
+    def test_write_location_root_bind_mode(self):
+        self.manager.write_location("myrpaas", "/", destination="http://myapp.tsuru.io", bind_mode=True)
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/ROOT")
+        expected = nginx.NGINX_LOCATION_TEMPLATE_DEFAULT.format(path="/",
+                                                                host="http://myapp.tsuru.io",
+                                                                upstream="rpaas_default_upstream")
+        self.assertEqual(expected, item[1]["Value"])
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/rpaas_default_upstream")
+        self.assertEqual("myapp.tsuru.io", item[1]["Value"])
+
     def test_write_location_root_router_mode(self):
         self.manager.write_location("router-myrpaas", "/", destination="router-myrpaas", router_mode=True)
         item = self.consul.kv.get("test-suite-rpaas/router-myrpaas/locations/ROOT")


### PR DESCRIPTION
Current upstream name method leads to conflict with previous bind proxy_pass
url which contains port. It causes nginx error on reload. Using a different
upstream name on instance bind avoids this problem.