### PR TITLE
api: use plan field when updating service instance

### DIFF
--- a/rpaas/api.py
+++ b/rpaas/api.py
@@ -91,6 +91,8 @@ def add_instance():
 def update_instance(name):
     plan = request.form.get("plan_name")
     if not plan:
+        plan = request.form.get("plan")
+    if not plan:
         return "Plan is required", 404
     try:
         get_manager().update_instance(name, plan)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,6 +132,10 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(204, resp.status_code)
         self.assertEqual("", resp.data)
         self.assertEqual("huge", self.manager.instances[0].plan)
+        resp = self.api.put("/resources/someapp", data={"plan": "small"})
+        self.assertEqual(204, resp.status_code)
+        self.assertEqual("", resp.data)
+        self.assertEqual("small", self.manager.instances[0].plan)
 
     def test_update_instance_not_found(self):
         self.storage.db[self.storage.plans_collection].insert(


### PR DESCRIPTION
tsuru API sends the `plan` argument while rpaas plugin uses the
`plan_name` argument. This commit allow both arguments as the new plan
name.