### PR TITLE
Manager: fix remove custom route content with empty destination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,10 @@ kill-redis-sentinel-test:
 	-redis-cli -p 51111 shutdown
 
 redis-sentinel-test: kill-redis-sentinel-test copy-redis-conf
-	redis-sentinel /tmp/redis_sentinel_test.conf --daemonize yes || redis-server /tmp/redis_sentinel_test.conf --sentinel --daemonize yes; sleep 1
-	redis-sentinel /tmp/redis_sentinel2_test.conf --daemonize yes || redis-server /tmp/redis_sentinel2_test.conf --sentinel --daemonize yes; sleep 1
+	redis-sentinel /tmp/redis_sentinel_test.conf --daemonize yes || redis-server /tmp/redis_sentinel_test.conf --sentinel --daemonize yes || \
+        redis-server /tmp/redis_sentinel_test.conf --daemonize yes || redis-server /tmp/redis_sentinel_test.conf --sentinel --daemonize yes; sleep 1
+	redis-sentinel /tmp/redis_sentinel2_test.conf --daemonize yes || redis-server /tmp/redis_sentinel2_test.conf --sentinel --daemonize yes || \
+	redis-server /tmp/redis_sentinel2_test.conf --daemonize yes || redis-server /tmp/redis_sentinel2_test.conf --sentinel --daemonize yes; sleep 1
 	redis-server /tmp/redis_test.conf --daemonize yes; sleep 1
 	redis-server /tmp/redis_test2.conf --daemonize yes; sleep 1
 	redis-server /tmp/redis_test3.conf --daemonize yes; sleep 1

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,8 @@ kill-redis-sentinel-test:
 	-redis-cli -p 51111 shutdown
 
 redis-sentinel-test: kill-redis-sentinel-test copy-redis-conf
-	redis-sentinel /tmp/redis_sentinel_test.conf --daemonize yes || redis-server /tmp/redis_sentinel_test.conf --sentinel --daemonize yes || \
-        redis-server /tmp/redis_sentinel_test.conf --daemonize yes || redis-server /tmp/redis_sentinel_test.conf --sentinel --daemonize yes; sleep 1
-	redis-sentinel /tmp/redis_sentinel2_test.conf --daemonize yes || redis-server /tmp/redis_sentinel2_test.conf --sentinel --daemonize yes || \
-	redis-server /tmp/redis_sentinel2_test.conf --daemonize yes || redis-server /tmp/redis_sentinel2_test.conf --sentinel --daemonize yes; sleep 1
+	redis-sentinel /tmp/redis_sentinel_test.conf --daemonize yes || redis-server /tmp/redis_sentinel_test.conf --sentinel --daemonize yes; sleep 1
+	redis-sentinel /tmp/redis_sentinel2_test.conf --daemonize yes || redis-server /tmp/redis_sentinel2_test.conf --sentinel --daemonize yes; sleep 1
 	redis-server /tmp/redis_test.conf --daemonize yes; sleep 1
 	redis-server /tmp/redis_test2.conf --daemonize yes; sleep 1
 	redis-server /tmp/redis_test3.conf --daemonize yes; sleep 1

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -369,9 +369,7 @@ class Manager(object):
         for p in routes['paths']:
             if destination and p['destination'] == destination:
                 destination_count += 1
-        if destination_count == 0:
-            raise storage.InstanceNotFoundError()
-        if destination_count < 2:
+        if destination_count == 1:
             self.consul_manager.remove_server_upstream(name, destination, destination)
         self.storage.delete_binding_path(name, path)
         self.consul_manager.remove_location(name, path)


### PR DESCRIPTION
Fix error when trying to remove an empty destionation route - rpaas actually returns wrong
"instance not found" error.