### PR TITLE
Add option to scale and change flavor to router_api

### DIFF
--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -240,7 +240,7 @@ class Manager(object):
                 if dst:
                     routes_data.append("destination = {}".format(dst))
                 if content:
-                    routes_data.append("content = {}".format(content.encode("utf-8")))  
+                    routes_data.append("content = {}".format(content.encode("utf-8")))
         lb = LoadBalancer.find(name)
         host_count = 0
         if lb:

--- a/rpaas/router_api.py
+++ b/rpaas/router_api.py
@@ -163,12 +163,8 @@ def status(name):
 def info():
     plans = get_manager().storage.list_plans()
     flavors = get_manager().storage.list_flavors()
-    options_plans = []
-    options_flavors = []
-    for p in [p.to_dict() for p in plans]:
-        options_plans.append("{} - {}".format(p['name'], p['description']))
-    for f in [f.to_dict() for f in flavors]:
-        options_flavors.append("{} - {}".format(f['name'], f['description']))
+    options_plans = ["{} - {}".format(p.name, p.description) for p in plans]
+    options_flavors = ["{} - {}".format(f.name, f.description) for f in flavors]
     options = """
 scale  - number of instance vms
 plan   - set instance to plan

--- a/rpaas/router_api.py
+++ b/rpaas/router_api.py
@@ -47,7 +47,6 @@ def add_backend(name):
     team = data.get('team') or data.get('tsuru.io/app-teamowner')
     plan = data.get('plan')
     flavor = data.get('flavor')
-    scale = data.get('scale')
     if not team:
         return "team name is required", 400
     if require_plan() and not plan:
@@ -162,7 +161,7 @@ def status(name):
 @router.route("/info", methods=["GET"])
 @auth.required
 def info():
-    plans   = get_manager().storage.list_plans()
+    plans = get_manager().storage.list_plans()
     flavors = get_manager().storage.list_flavors()
     options_plans = []
     options_flavors = []

--- a/tests/test_router_api.py
+++ b/tests/test_router_api.py
@@ -73,7 +73,8 @@ class RouterAPITestCase(unittest.TestCase):
         self.assertEqual(201, resp.status_code)
         self.assertEqual("router-someapp", self.manager.instances[0].name)
         self.assertEqual("small", self.manager.instances[0].plan)
-        resp = self.api.post("/router/backend/otherapp", data=json.dumps({"team": "team1", "plan": "small", "flavor": "vanilla"}),
+        resp = self.api.post("/router/backend/otherapp", data=json.dumps({"team": "team1", "plan": "small",
+                                                                          "flavor": "vanilla"}),
                              content_type="application/json")
         self.assertEqual(201, resp.status_code)
         self.assertEqual("router-otherapp", self.manager.instances[1].name)
@@ -138,7 +139,8 @@ class RouterAPITestCase(unittest.TestCase):
         self.assertEqual("", resp.data)
         self.assertEqual(204, resp.status_code)
         self.assertEqual("vanilla", self.manager.instances[0].flavor)
-        resp = self.api.put("/router/backend/someapp", data=json.dumps({"flavor": "orange", "plan": "small", "scale": 3}),
+        resp = self.api.put("/router/backend/someapp", data=json.dumps({"flavor": "orange", "plan": "small",
+                                                                        "scale": 3}),
                             content_type="application/json")
         self.assertEqual("", resp.data)
         self.assertEqual(204, resp.status_code)
@@ -199,15 +201,15 @@ class RouterAPITestCase(unittest.TestCase):
         self.assertEqual("Flavor not found", resp.data)
 
     def test_update_backend_invalid_scale_value(self):
-       self.manager.new_instance("router-someapp")
-       resp = self.api.put("/router/backend/someapp", data=json.dumps({"scale":"a"}),
-                           content_type="application/json")
-       self.assertEqual(400, resp.status_code)
-       self.assertEqual("Scale option should be integer and >0", resp.data)
-       resp = self.api.put("/router/backend/someapp", data=json.dumps({"scale":"0"}),
-                           content_type="application/json")
-       self.assertEqual(400, resp.status_code)
-       self.assertEqual("Scale option should be integer and >0", resp.data)
+        self.manager.new_instance("router-someapp")
+        resp = self.api.put("/router/backend/someapp", data=json.dumps({"scale": "a"}),
+                            content_type="application/json")
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual("Scale option should be integer and >0", resp.data)
+        resp = self.api.put("/router/backend/someapp", data=json.dumps({"scale": "0"}),
+                            content_type="application/json")
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual("Scale option should be integer and >0", resp.data)
 
     def test_delete_backend(self):
         self.manager.new_instance("router-someapp")

--- a/tests/test_router_api.py
+++ b/tests/test_router_api.py
@@ -193,6 +193,44 @@ class RouterAPITestCase(unittest.TestCase):
         self.assertEqual(200, resp.status_code)
         self.assertEqual(resp.data, '{"status": "vm-1 - 10.1.1.1: OK\\nvm-2 - 10.2.2.2: DEAD"}')
 
+    def test_get_info(self):
+        self.storage.db[self.storage.plans_collection].insert(
+            {"_id": "small",
+             "description": "some cool plan",
+             "config": {"serviceofferingid": "abcdef123456"}}
+        )
+        self.storage.db[self.storage.plans_collection].insert(
+            {"_id": "huge",
+             "description": "some cool huge plan",
+             "config": {"serviceofferingid": "abcdef123459"}}
+        )
+        self.storage.db[self.storage.flavors_collection].insert(
+            {"_id": "vanilla",
+             "description": "nginx 1.12",
+             "config": {"nginx_version": "1.12"}}
+        )
+        self.storage.db[self.storage.flavors_collection].insert(
+            {"_id": "orange",
+             "description": "nginx 1.13",
+             "config": {"nginx_version": "1.13"}}
+        )
+        resp = self.api.get("/router/info")
+        self.assertEqual(200, resp.status_code)
+        info_return = '''{"Router options": "\\n
+                           scale  - number of instance vms\\n
+                           plan   - set instance to plan\\n
+                           flavor - set instance to flavor\\n\\n
+
+                           Available plans: \\n
+                           small - some cool plan\\n
+                           huge - some cool huge plan\\n\\n
+
+                           Available flavors: \\n
+                           vanilla - nginx 1.12\\n
+                           orange - nginx 1.13"}'''
+        info_return = info_return.replace("\n", "").replace(" " * 27, "")
+        self.assertEqual(resp.data, info_return)
+
     def test_remove_routes(self):
         self.manager.new_instance("router-someapp")
         self.manager.add_upstream(

--- a/tests/test_router_api.py
+++ b/tests/test_router_api.py
@@ -185,6 +185,14 @@ class RouterAPITestCase(unittest.TestCase):
             "router-someapp", "router-someapp")
         self.assertEqual(["addr1", "addr2"], sorted(list(routes)))
 
+    def test_get_status(self):
+        instance = self.manager.new_instance("router-someapp")
+        instance.node_status = {'vm-1': {'status': 'OK', 'address': '10.1.1.1'},
+                                'vm-2': {'status': 'DEAD', 'address': '10.2.2.2'}}
+        resp = self.api.get("/router/backend/someapp/status")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(resp.data, '{"status": "vm-1 - 10.1.1.1: OK\\nvm-2 - 10.2.2.2: DEAD"}')
+
     def test_remove_routes(self):
         self.manager.new_instance("router-someapp")
         self.manager.add_upstream(


### PR DESCRIPTION
Add option to scale and change flavor to router_api - related to #46 
Also, add option to return info about router options and status of created instance machines