### PR TITLE
plugin: add route option to force https

### DIFF
--- a/rpaas/api.py
+++ b/rpaas/api.py
@@ -307,6 +307,7 @@ def add_route(name):
         return 'missing path', 400
     destination = request.form.get('destination')
     content = request.form.get('content')
+    https_only = bool(request.form.get('https_only')) or False
     if not destination and not content:
         return 'either content xor destination are required', 400
     if destination and content:
@@ -314,7 +315,7 @@ def add_route(name):
     if content:
         content = content.encode("utf-8")
     try:
-        get_manager().add_route(name, path, destination, content)
+        get_manager().add_route(name, path, destination, content, https_only)
     except storage.InstanceNotFoundError:
         return "Instance not found", 404
     except tasks.NotReadyError as e:

--- a/rpaas/consul_manager.py
+++ b/rpaas/consul_manager.py
@@ -86,7 +86,8 @@ class ConsulManager(object):
                 node_status_list[node_server_name] = node['Value']
         return node_status_list
 
-    def write_location(self, instance_name, path, destination=None, content=None, router_mode=False, bind_mode=False):
+    def write_location(self, instance_name, path, destination=None, content=None, router_mode=False,
+                       bind_mode=False, https_only=False):
         if content:
             content = content.strip()
         else:
@@ -94,7 +95,7 @@ class ConsulManager(object):
             upstream_server = upstream
             if bind_mode:
                 upstream = "rpaas_default_upstream"
-            content = self.config_manager.generate_host_config(path, destination, upstream, router_mode)
+            content = self.config_manager.generate_host_config(path, destination, upstream, router_mode, https_only)
             if router_mode:
                 upstream_server = None
             self.add_server_upstream(instance_name, upstream, upstream_server)

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -237,6 +237,9 @@ class Manager(object):
                 routes_data.append("path = {}".format(path_data["path"]))
                 dst = path_data.get("destination")
                 content = path_data.get("content")
+                https_only = path_data.get("https_only")
+                if https_only and dst:
+                    dst = "{} (https only)".format(dst)
                 if dst:
                     routes_data.append("destination = {}".format(dst))
                 if content:
@@ -380,7 +383,7 @@ class Manager(object):
         lb = LoadBalancer.find(name)
         if lb is None:
             raise storage.InstanceNotFoundError()
-        self.storage.replace_binding_path(name, path, destination, content)
+        self.storage.replace_binding_path(name, path, destination, content, https_only)
         self.consul_manager.write_location(name, path, destination=destination,
                                            content=content, https_only=https_only)
 

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -211,7 +211,7 @@ class Manager(object):
                 raise BindError("This service can only be bound to one application.")
         bind_mode = not router_mode
         self.consul_manager.write_location(name, "/", destination=app_host, router_mode=router_mode,
-                                           bind_mode=bind_mode)
+                                           bind_mode=bind_mode, https_only=False)
         self.storage.store_binding(name, app_host)
 
     def unbind(self, name):
@@ -374,7 +374,7 @@ class Manager(object):
         task = tasks.ScaleInstanceTask().delay(config, name, quantity)
         self.task_manager.update(name, task.task_id)
 
-    def add_route(self, name, path, destination, content):
+    def add_route(self, name, path, destination, content, https_only):
         self.task_manager.ensure_ready(name)
         path = path.strip()
         lb = LoadBalancer.find(name)
@@ -382,7 +382,7 @@ class Manager(object):
             raise storage.InstanceNotFoundError()
         self.storage.replace_binding_path(name, path, destination, content)
         self.consul_manager.write_location(name, path, destination=destination,
-                                           content=content)
+                                           content=content, https_only=https_only)
 
     def delete_route(self, name, path):
         self.task_manager.ensure_ready(name)

--- a/rpaas/plugin.py
+++ b/rpaas/plugin.py
@@ -129,6 +129,8 @@ def route(args):
             params['destination'] = args.destination
         if args.content:
             params['content'] = args.content
+        if args.https_only:
+            params['https_only'] = True
         method = "POST"
         message = "added"
     elif args.action == 'remove':
@@ -152,7 +154,13 @@ def route(args):
             sys.stdout.write("Routes:\n")
             for route in routes:
                 out.append("path = {}".format(route.get('path')))
-                out.append("content = {}".format(route.get('content')))
+                if route.get('content'):
+                    out.append("content = {}".format(route.get('content')))
+                    continue
+                if route.get('https_only'):
+                    out.append("destination = {} (https only)".format(route.get('destination')))
+                else:
+                    out.append("destination = {}".format(route.get('destination')))
             sys.stdout.write('\n'.join(out) + '\n')
         else:
             sys.stdout.write("route successfully {}\n".format(message))
@@ -429,6 +437,8 @@ def get_route_args(args):
     parser.add_argument("-i", "--instance", required=True, help="Instance name")
     parser.add_argument("-p", "--path", required=False, help="Path to route")
     parser.add_argument("-d", "--destination", required=False, help="Destination host")
+    parser.add_argument("--https_only", required=False, action="store_true",
+                        help="Force redirect to https - only for destination")
     parser.add_argument("-c", "--content", required=False,
                         help="(advanced) raw nginx location content")
     parsed = parser.parse_args(args)

--- a/rpaas/storage.py
+++ b/rpaas/storage.py
@@ -208,7 +208,7 @@ class MongoDBStorage(storage.MongoDBStorage):
     def find_binding(self, name):
         return self.db[self.bindings_collection].find_one({'_id': name})
 
-    def replace_binding_path(self, name, path, destination=None, content=None):
+    def replace_binding_path(self, name, path, destination=None, content=None, https_only=False):
         try:
             self.delete_binding_path(name, path)
         except:
@@ -217,6 +217,7 @@ class MongoDBStorage(storage.MongoDBStorage):
             'path': path,
             'destination': destination,
             'content': content,
+            'https_only': https_only
         }}}, upsert=True)
 
     def delete_binding_path(self, name, path):

--- a/tests/managers.py
+++ b/tests/managers.py
@@ -134,9 +134,9 @@ class FakeManager(object):
                 return i, instance
         return -1, None
 
-    def add_route(self, name, path, destination, content):
+    def add_route(self, name, path, destination, content, https_only):
         _, instance = self.find_instance(name)
-        instance.routes[path] = {'destination': destination, 'content': content}
+        instance.routes[path] = {'destination': destination, 'content': content, 'https_only': https_only}
 
     def delete_route(self, name, path):
         _, instance = self.find_instance(name)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -619,6 +619,22 @@ class APITestCase(unittest.TestCase):
         self.assertDictEqual(instance.routes.get('/somewhere'), {
             'destination': 'something',
             'content': None,
+            'https_only': False
+        })
+
+    def test_add_route_forcing_https(self):
+        self.manager.new_instance("someapp")
+        resp = self.api.post("/resources/someapp/route", data={
+            'path': '/somewhere',
+            'destination': 'something',
+            'https_only': 'true'
+        })
+        self.assertEqual(201, resp.status_code)
+        _, instance = self.manager.find_instance("someapp")
+        self.assertDictEqual(instance.routes.get('/somewhere'), {
+            'destination': 'something',
+            'content': None,
+            'https_only': True
         })
 
     def test_add_route_with_content(self):
@@ -632,6 +648,7 @@ class APITestCase(unittest.TestCase):
         self.assertDictEqual(instance.routes.get('/somewhere'), {
             'destination': None,
             'content': 'my content',
+            'https_only': False
         })
 
     def test_add_route_with_utf8_content(self):
@@ -644,7 +661,8 @@ class APITestCase(unittest.TestCase):
         _, instance = self.manager.find_instance("someapp")
         self.assertDictEqual(instance.routes.get('/somewhere'), {
             'destination': None,
-            'content': 'my content ☺'
+            'content': 'my content ☺',
+            'https_only': False
         })
 
     def test_delete_route(self):

--- a/tests/test_consul_manager.py
+++ b/tests/test_consul_manager.py
@@ -114,7 +114,19 @@ class ConsulManagerTestCase(unittest.TestCase):
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/ROOT")
         expected = nginx.NGINX_LOCATION_TEMPLATE_DEFAULT.format(path="/",
                                                                 host="http://myapp.tsuru.io",
-                                                                upstream="myapp.tsuru.io")
+                                                                upstream="myapp.tsuru.io",
+                                                                https_only='')
+        self.assertEqual(expected, item[1]["Value"])
+        servers = self.manager.list_upstream("myrpaas", "myapp.tsuru.io")
+        self.assertEqual(set(["myapp.tsuru.io"]), servers)
+
+    def test_write_location_root_with_https(self):
+        self.manager.write_location("myrpaas", "/", destination="http://myapp.tsuru.io", https_only=True)
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/ROOT")
+        expected = nginx.NGINX_LOCATION_TEMPLATE_DEFAULT.format(path="/",
+                                                                host="http://myapp.tsuru.io",
+                                                                upstream="myapp.tsuru.io",
+                                                                https_only=nginx.NGINX_HTTPS_ONLY)
         self.assertEqual(expected, item[1]["Value"])
         servers = self.manager.list_upstream("myrpaas", "myapp.tsuru.io")
         self.assertEqual(set(["myapp.tsuru.io"]), servers)
@@ -124,7 +136,8 @@ class ConsulManagerTestCase(unittest.TestCase):
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/ROOT")
         expected = nginx.NGINX_LOCATION_TEMPLATE_DEFAULT.format(path="/",
                                                                 host="http://myapp.tsuru.io",
-                                                                upstream="rpaas_default_upstream")
+                                                                upstream="rpaas_default_upstream",
+                                                                https_only='')
         self.assertEqual(expected, item[1]["Value"])
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/rpaas_default_upstream")
         servers = self.manager.list_upstream("myrpaas", "rpaas_default_upstream")
@@ -135,7 +148,8 @@ class ConsulManagerTestCase(unittest.TestCase):
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/ROOT")
         expected = nginx.NGINX_LOCATION_TEMPLATE_ROUTER.format(path="/",
                                                                host="router-myrpaas",
-                                                               upstream="router-myrpaas")
+                                                               upstream="router-myrpaas",
+                                                               https_only='')
         self.assertEqual(expected, item[1]["Value"])
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/upstream/router-myrpaas")
         self.assertEqual(None, item[1])
@@ -146,7 +160,18 @@ class ConsulManagerTestCase(unittest.TestCase):
         item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/___admin___app_sites___")
         expected = nginx.NGINX_LOCATION_TEMPLATE_DEFAULT.format(path="/admin/app_sites/",
                                                                 host="http://myapp.tsuru.io",
-                                                                upstream="myapp.tsuru.io")
+                                                                upstream="myapp.tsuru.io",
+                                                                https_only='')
+        self.assertEqual(expected, item[1]["Value"])
+
+    def test_write_location_non_root_with_https(self):
+        self.manager.write_location("myrpaas", "/admin/app_sites/",
+                                    destination="http://myapp.tsuru.io", https_only=True)
+        item = self.consul.kv.get("test-suite-rpaas/myrpaas/locations/___admin___app_sites___")
+        expected = nginx.NGINX_LOCATION_TEMPLATE_DEFAULT.format(path="/admin/app_sites/",
+                                                                host="http://myapp.tsuru.io",
+                                                                upstream="myapp.tsuru.io",
+                                                                https_only=nginx.NGINX_HTTPS_ONLY)
         self.assertEqual(expected, item[1]["Value"])
 
     def test_write_location_content(self):


### PR DESCRIPTION
Add --https-only option for `route add` to force redirect destinations to https

Closes #4 