### PR TITLE
Allow removing an instance without destroy its load balancer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Babel==2.3.4",
         "zope.interface==4.3.3",
         "parsedatetime==2.1",
+        "redis==2.10.6",
     ],
     extras_require={
         'tests': [

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -75,7 +75,7 @@ class TasksTestCase(unittest.TestCase):
         redis_conn.execute_command("sentinel failover mymaster")
         redis_conn = redis.StrictRedis().from_url("redis://:mypass@127.0.0.1:{}".format(self.master_port))
         timeout_failover = 0
-        while redis_conn.info()['role'] is not 'slave' and timeout_failover <= 30:
+        while redis_conn.info()['role'] == 'slave' and timeout_failover <= 30:
             time.sleep(1)
             timeout_failover += 1
         self.assertEqual(ch.client.info()['role'], 'master')


### PR DESCRIPTION
Prior PR, the load balancer was always destroyed at remove instance task. There are cases we need retain it, such as reuse your IP address e.g. This PR adds a new configuration (as env var) that skip the load balancer removal when enabled.