### PR TITLE
manager: unbind do not remove / path anymore for custom routes

### DIFF
--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -222,6 +222,10 @@ class Manager(object):
         binding_data = self.storage.find_binding(name)
         if not binding_data:
             return
+        paths = binding_data.get("paths")
+        for path in paths:
+            if path.get("path") == "/" and "content" in path:
+                return
         bound_host = binding_data.get("app_host")
         self.storage.remove_root_binding(name)
         self.consul_manager.write_location(name, "/", content=nginx.NGINX_LOCATION_INSTANCE_NOT_BOUND)


### PR DESCRIPTION
When unbind is called, rpaas always remove "/" path and returns "instance not bound" even if "/" path is custom or not. This PR chance this behavior and now only removes it when route is not customized.