### PR TITLE
manager: bind also do not replaces / path anymore when it is customized

### DIFF
--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -209,6 +209,10 @@ class Manager(object):
                 return
             if bound_host is not None:
                 raise BindError("This service can only be bound to one application.")
+            paths = binding_data.get("paths")
+            for path in paths:
+                if path.get("path") == "/" and "content" in path:
+                    return
         bind_mode = not router_mode
         self.consul_manager.write_location(name, "/", destination=app_host, router_mode=router_mode,
                                            bind_mode=bind_mode, https_only=False)

--- a/rpaas/manager.py
+++ b/rpaas/manager.py
@@ -212,6 +212,7 @@ class Manager(object):
             paths = binding_data.get("paths")
             for path in paths:
                 if path.get("path") == "/" and "content" in path:
+                    self.storage.store_binding(name, app_host, app_host_only=True)
                     return
         bind_mode = not router_mode
         self.consul_manager.write_location(name, "/", destination=app_host, router_mode=router_mode,
@@ -229,9 +230,10 @@ class Manager(object):
         paths = binding_data.get("paths")
         for path in paths:
             if path.get("path") == "/" and "content" in path:
+                self.storage.remove_root_binding(name, False)
                 return
         bound_host = binding_data.get("app_host")
-        self.storage.remove_root_binding(name)
+        self.storage.remove_root_binding(name, True)
         self.consul_manager.write_location(name, "/", content=nginx.NGINX_LOCATION_INSTANCE_NOT_BOUND)
         self.consul_manager.remove_server_upstream(name, "rpaas_default_upstream", bound_host)
 

--- a/rpaas/storage.py
+++ b/rpaas/storage.py
@@ -183,7 +183,12 @@ class MongoDBStorage(storage.MongoDBStorage):
         del dict["_id"]
         return flavor.Flavor(**dict)
 
-    def store_binding(self, name, app_host):
+    def store_binding(self, name, app_host, app_host_only=False):
+        if app_host_only:
+            self.db[self.bindings_collection].update({'_id': name}, {
+                '$set': {'app_host': app_host}
+            }, upsert=True)
+            return
         try:
             self.delete_binding_path(name, '/')
         except:
@@ -199,8 +204,9 @@ class MongoDBStorage(storage.MongoDBStorage):
     def remove_binding(self, name):
         self.db[self.bindings_collection].remove({'_id': name})
 
-    def remove_root_binding(self, name):
-        self.delete_binding_path(name, '/')
+    def remove_root_binding(self, name, remove_root_binding_path):
+        if remove_root_binding_path:
+            self.delete_binding_path(name, '/')
         self.db[self.bindings_collection].update({'_id': name}, {
             '$unset': {'app_host': '1'}
         })

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -868,20 +868,40 @@ destination = app1.host.com (https only)"""},
         manager = Manager(self.config)
         manager.consul_manager = mock.Mock()
         manager.add_route("x", "/somewhere", "my.other.host", None, False)
+        manager.add_route("x", "/", "my.other.host2", None, False)
         manager.bind("x", "apphost.com")
         binding_data = self.storage.find_binding("x")
         self.assertDictEqual(binding_data, {
             "_id": "x",
-            "app_host": "apphost.com",
             "paths": [
                 {"path": "/somewhere", "destination": "my.other.host", "content": None, "https_only": False},
-                {"path": "/", "destination": "apphost.com"}
+                {"path": "/", "destination": "my.other.host2", "content": None, "https_only": False, }
             ]
         })
         LoadBalancer.find.assert_called_with("x")
-        expected_calls = [mock.call("x", "/somewhere", destination="my.other.host", content=None, https_only=False),
-                          mock.call("x", "/", destination="apphost.com", router_mode=False, bind_mode=True,
-                                    https_only=False)]
+        expected_calls = [mock.call("x", "/somewhere", destination="my.other.host", content=None, https_only=False)]
+        manager.consul_manager.write_location.assert_has_calls(expected_calls)
+
+    @mock.patch("rpaas.manager.LoadBalancer")
+    def test_add_route_bind_and_unbind(self, LoadBalancer):
+        lb = LoadBalancer.find.return_value
+        lb.hosts = [mock.Mock(), mock.Mock()]
+        lb.hosts[0].dns_name = "h1"
+        lb.hosts[1].dns_name = "h2"
+        manager = Manager(self.config)
+        manager.consul_manager = mock.Mock()
+        manager.add_route("x", "/", "my.other.host", None, False)
+        manager.bind("x", "apphost.com")
+        manager.unbind("x")
+        binding_data = self.storage.find_binding("x")
+        self.assertDictEqual(binding_data, {
+            "_id": "x",
+            "paths": [
+                {"path": "/", "destination": "my.other.host", "content": None, "https_only": False, }
+            ]
+        })
+        LoadBalancer.find.assert_called_with("x")
+        expected_calls = [mock.call("x", "/", destination="my.other.host", content=None, https_only=False)]
         manager.consul_manager.write_location.assert_has_calls(expected_calls)
 
     @mock.patch("rpaas.manager.LoadBalancer")

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -873,13 +873,15 @@ destination = app1.host.com (https only)"""},
         binding_data = self.storage.find_binding("x")
         self.assertDictEqual(binding_data, {
             "_id": "x",
+            "app_host": "apphost.com",
             "paths": [
                 {"path": "/somewhere", "destination": "my.other.host", "content": None, "https_only": False},
                 {"path": "/", "destination": "my.other.host2", "content": None, "https_only": False, }
             ]
         })
         LoadBalancer.find.assert_called_with("x")
-        expected_calls = [mock.call("x", "/somewhere", destination="my.other.host", content=None, https_only=False)]
+        expected_calls = [mock.call("x", "/somewhere", destination="my.other.host", content=None, https_only=False),
+                          mock.call("x", "/", destination="my.other.host2", content=None, https_only=False)]
         manager.consul_manager.write_location.assert_has_calls(expected_calls)
 
     @mock.patch("rpaas.manager.LoadBalancer")
@@ -902,6 +904,32 @@ destination = app1.host.com (https only)"""},
         })
         LoadBalancer.find.assert_called_with("x")
         expected_calls = [mock.call("x", "/", destination="my.other.host", content=None, https_only=False)]
+        manager.consul_manager.write_location.assert_has_calls(expected_calls)
+
+    @mock.patch("rpaas.manager.LoadBalancer")
+    def test_bind_on_x_add_route_unbind_and_bind_on_otherhost(self, LoadBalancer):
+        lb = LoadBalancer.find.return_value
+        lb.hosts = [mock.Mock(), mock.Mock()]
+        lb.hosts[0].dns_name = "h1"
+        lb.hosts[1].dns_name = "h2"
+        manager = Manager(self.config)
+        manager.consul_manager = mock.Mock()
+        manager.bind("x", "apphost.com")
+        manager.add_route("x", "/", "my.custom.host", None, False)
+        manager.unbind("x")
+        manager.bind("x", "otherhost.com")
+        binding_data = self.storage.find_binding("x")
+        self.assertDictEqual(binding_data, {
+            "_id": "x",
+            "app_host": "otherhost.com",
+            "paths": [
+                {"path": "/", "destination": "my.custom.host", "content": None, "https_only": False}
+            ]
+        })
+        LoadBalancer.find.assert_called_with("x")
+        expected_calls = [mock.call("x", "/", destination="apphost.com", router_mode=False, bind_mode=True,
+                                    https_only=False),
+                          mock.call("x", "/", destination="my.custom.host", content=None, https_only=False)]
         manager.consul_manager.write_location.assert_has_calls(expected_calls)
 
     @mock.patch("rpaas.manager.LoadBalancer")
@@ -935,7 +963,6 @@ destination = app1.host.com (https only)"""},
         binding_data = self.storage.find_binding("inst")
         self.assertDictEqual(binding_data, {
             "_id": "inst",
-            "app_host": "app.host.com",
             "paths": [
                 {"path": "/", "destination": "my.other.host", "content": None, "https_only": False}
             ]


### PR DESCRIPTION
As modified to `unbind`, `bind` also should not modify customized `/` path 